### PR TITLE
[Reviewer: Graeme] Quote params in WWW-Authenticate header

### DIFF
--- a/src/httpdigestauthenticate.cpp
+++ b/src/httpdigestauthenticate.cpp
@@ -479,7 +479,7 @@ void HTTPDigestAuthenticate::generate_www_auth_header(std::string& www_auth_head
 
   if (include_stale)
   {
-    www_auth_header.append(",stale=TRUE");
+    www_auth_header.append(",stale=\"TRUE\"");
   }
 
   LOG_DEBUG("WWW-Authenticate header generated: %s", www_auth_header.c_str());

--- a/src/ut/httpdigestauthenticate_test.cpp
+++ b/src/ut/httpdigestauthenticate_test.cpp
@@ -222,7 +222,7 @@ TEST_F(HTTPDigestAuthenticateTest, RequestStoreDigest)
   long rc = _auth_mod->request_digest_and_store(www_auth_header, false, _response);
 
   EXPECT_THAT(www_auth_header,
-              MatchesRegex("Digest realm=\"home.domain\",qop=\"auth\",nonce=\".*/KspN6ry7jG8CU4b\",opaque=\".*onN2aujzfJamyN3xYja\""));
+              MatchesRegex("Digest realm=\"home\\.domain\",qop=\"auth\",nonce=\".*/KspN6ry7jG8CU4b\",opaque=\".*onN2aujzfJamyN3xYja\""));
   ASSERT_EQ(rc, 401);
 }
 
@@ -242,7 +242,7 @@ TEST_F(HTTPDigestAuthenticateTest, RequestStoreDigest_Stale)
   long rc = _auth_mod->request_digest_and_store(www_auth_header, true, _response);
 
   EXPECT_THAT(www_auth_header,
-              MatchesRegex("Digest realm=\"home.domain\",qop=\"auth\",nonce=\".*dFXYpeUryNGb0UROC0\",opaque=\".*Bh9cHwp\\+hBh8n\\+B\\+Xqc\",stale=TRUE"));
+              MatchesRegex("Digest realm=\"home\\.domain\",qop=\"auth\",nonce=\".*dFXYpeUryNGb0UROC0\",opaque=\".*Bh9cHwp\\+hBh8n\\+B\\+Xqc\",stale=\"TRUE\""));
   ASSERT_EQ(rc, 401);
 }
 


### PR DESCRIPTION
Graeme, can you review this fix to quote the params in the WWW-Authenticate header
Tested in UTs. 

Fixes #1 
