### PR TITLE
Reviewer AMC: Remove SSLv2 and SSLv3 from memento nginx ssl_protocols

### DIFF
--- a/memento-nginx.root/usr/share/clearwater/infrastructure/scripts/create-memento-nginx-config
+++ b/memento-nginx.root/usr/share/clearwater/infrastructure/scripts/create-memento-nginx-config
@@ -63,8 +63,8 @@ server {
 
         ssl_session_timeout  5m;
 
-        ssl_protocols  TLSv1;
-        ssl_ciphers  ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP;
+        ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers  ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;
         ssl_prefer_server_ciphers   on;
 
         # <memento_hostname>/ping tests memento through nginx. localhost/ping


### PR DESCRIPTION
Andy, please review this previously discussed change.

It fixes https://github.com/Metaswitch/memento/issues/18.

I'll update sprout too to reflect this submodule change.

This is untested.
