### PR TITLE
[Reviewer: Ellie] Enhance memento to uses CASs when interacting with memcached.

### DIFF
--- a/include/authstore.h
+++ b/include/authstore.h
@@ -94,7 +94,7 @@ public:
             int expiry);
 
   /// Destructor.
-  ~AuthStore();
+  virtual ~AuthStore();
 
   /// set_digest.
   ///
@@ -103,10 +103,10 @@ public:
   /// @param digest A pointer to a Digest object to store
   ///
   /// @return       The status code returned by the store.
-  Store::Status set_digest(const std::string& impi,
-                           const std::string& nonce,
-                           const Digest*,
-                           SAS::TrailId);
+  virtual Store::Status set_digest(const std::string& impi,
+                                   const std::string& nonce,
+                                   const Digest*,
+                                   SAS::TrailId);
 
   /// get_digest.
   ///
@@ -116,10 +116,10 @@ public:
   ///               responsible for deleting
   ///
   /// @return       The status code returned by the store.
-  Store::Status get_digest(const std::string& impi,
-                           const std::string& nonce,
-                           Digest*&,
-                           SAS::TrailId);
+  virtual Store::Status get_digest(const std::string& impi,
+                                   const std::string& nonce,
+                                   Digest*&,
+                                   SAS::TrailId);
 
 private:
   std::string serialize_digest(const Digest* digest);

--- a/include/authstore.h
+++ b/include/authstore.h
@@ -97,17 +97,29 @@ public:
   ~AuthStore();
 
   /// set_digest.
+  ///
   /// @param impi   A reference to the private user identity.
   /// @param nonce  A reference to the nonce.
   /// @param digest A pointer to a Digest object to store
-  bool set_digest(const std::string& impi, const std::string& nonce, const Digest*, SAS::TrailId);
+  ///
+  /// @return       The status code returned by the store.
+  Store::Status set_digest(const std::string& impi,
+                           const std::string& nonce,
+                           const Digest*,
+                           SAS::TrailId);
 
-  /// set_digest.
+  /// get_digest.
+  ///
   /// @param impi   A reference to the private user identity.
   /// @param nonce  A reference to the nonce.
   /// @param digest A Digest object to populate with the retrieved Digest. Caller is
   ///               responsible for deleting
-  bool get_digest(const std::string& impi, const std::string& nonce, Digest*&, SAS::TrailId);
+  ///
+  /// @return       The status code returned by the store.
+  Store::Status get_digest(const std::string& impi,
+                           const std::string& nonce,
+                           Digest*&,
+                           SAS::TrailId);
 
 private:
   std::string serialize_digest(const Digest* digest);

--- a/include/authstore.h
+++ b/include/authstore.h
@@ -78,6 +78,13 @@ public:
 
     /// Destructor.
     ~Digest();
+
+  private:
+    /// Memcached CAS value.
+    uint64_t _cas;
+
+    // The auth store is a friend so it can read the digest's CAS value.
+    friend class AuthStore;
   };
 
   /// Constructor.

--- a/src/authstore.cpp
+++ b/src/authstore.cpp
@@ -64,7 +64,12 @@ bool AuthStore::set_digest(const std::string& impi,
 
   LOG_DEBUG("Set digest for %s\n%s", key.c_str(), data.c_str());
 
-  Store::Status status = _data_store->set_data("AuthStore", key, data, 0, _expiry, trail);
+  Store::Status status = _data_store->set_data("AuthStore",
+                                               key,
+                                               data,
+                                               digest->_cas,
+                                               _expiry,
+                                               trail);
 
   if (status != Store::Status::OK)
   {
@@ -120,6 +125,7 @@ bool AuthStore::get_digest(const std::string& impi,
   SAS::report_event(event);
 
   digest = deserialize_digest(data);
+  digest->_cas = cas;
   return true;
 }
 
@@ -130,7 +136,8 @@ AuthStore::Digest::Digest() :
   _impi(""),
   _realm(""),
   _nonce_count(1),
-  _impu("")
+  _impu(""),
+  _cas(0)
 {
 }
 

--- a/src/httpdigestauthenticate.cpp
+++ b/src/httpdigestauthenticate.cpp
@@ -443,7 +443,7 @@ HTTPCode HTTPDigestAuthenticate::check_if_matches(AuthStore::Digest* digest,
                                                        digest->_nonce,
                                                        digest,
                                                        _trail);
-      LOG_DEBUG("Updateing nonce count - store returned %d", store_rc);
+      LOG_DEBUG("Updating nonce count - store returned %d", store_rc);
 
       if (store_rc == Store::DATA_CONTENTION)
       {

--- a/src/httpdigestauthenticate.cpp
+++ b/src/httpdigestauthenticate.cpp
@@ -439,11 +439,33 @@ HTTPCode HTTPDigestAuthenticate::check_if_matches(AuthStore::Digest* digest,
     {
       // Authentication successful. Increment the stored nonce count
       digest->_nonce_count++;
-      _auth_store->set_digest(_impi, digest->_nonce, digest, _trail);
-      SAS::Event event(_trail, SASEvent::AUTHENTICATION_ACCEPTED, 0);
-      SAS::report_event(event);
+      Store::Status store_rc = _auth_store->set_digest(_impi,
+                                                       digest->_nonce,
+                                                       digest,
+                                                       _trail);
+      LOG_DEBUG("Updateing nonce count - store returned %d", store_rc);
 
-      _stat_auth_success_count->increment();
+      if (store_rc == Store::DATA_CONTENTION)
+      {
+        // The write to the store failed due to a CAS mismatch.  This means that
+        // the digest has already been used to authenticate another request, so
+        // the authentication on this request is stale. Rechallenge.
+        LOG_DEBUG("Failed to update nonce count - rechallenge");
+        SAS::Event event(_trail, SASEvent::AUTHENTICATION_OUT_OF_DATE, 1);
+        SAS::report_event(event);
+        rc = request_digest_and_store(www_auth_header, true, response);
+      }
+      else
+      {
+        // The nonce count was either updated successfully (in which case we
+        // accept the request) or the store failed (in which case we're not sure
+        // what to do for the best, and accepting the request is sensible
+        // default behaviour).
+        LOG_DEBUG("Authentication accepted");
+        SAS::Event event(_trail, SASEvent::AUTHENTICATION_ACCEPTED, 0);
+        SAS::report_event(event);
+        _stat_auth_success_count->increment();
+      }
     }
   }
   else

--- a/src/httpdigestauthenticate.cpp
+++ b/src/httpdigestauthenticate.cpp
@@ -279,9 +279,9 @@ HTTPCode HTTPDigestAuthenticate::retrieve_digest_from_store(std::string& www_aut
   _stat_auth_attempt_count->increment();
 
   AuthStore::Digest* digest;
-  bool success = _auth_store->get_digest(_impi, response->_nonce, digest, _trail);
+  Store::Status store_rc = _auth_store->get_digest(_impi, response->_nonce, digest, _trail);
 
-  if (success)
+  if (store_rc == Store::OK)
   {
     // Successfully retrieved digest, so check whether it matches
     // the response sent by the client
@@ -321,9 +321,9 @@ HTTPCode HTTPDigestAuthenticate::request_digest_and_store(std::string& www_auth_
     LOG_DEBUG("Store digest for IMPU: %s, IMPI: %s", _impu.c_str(), _impi.c_str());
     AuthStore::Digest* digest = new AuthStore::Digest();
     generate_digest(ha1, realm, digest);
-    bool success = _auth_store->set_digest(_impi, digest->_nonce, digest, _trail);
+    Store::Status status = _auth_store->set_digest(_impi, digest->_nonce, digest, _trail);
 
-    if (success)
+    if (status == Store::OK)
     {
       // Update statistics - either stale or (initial) challenge.
       if (include_stale)

--- a/src/ut/httpdigestauthenticate_test.cpp
+++ b/src/ut/httpdigestauthenticate_test.cpp
@@ -48,20 +48,48 @@
 #include "test_interposer.hpp"
 #include "fakehomesteadconnection.hpp"
 #include "fakecounter.h"
+#include "mockauthstore.h"
 
 using namespace std;
 using testing::MatchesRegex;
+using testing::Return;
+using testing::_;
 
 const SAS::TrailId DUMMY_TRAIL_ID = 0x1122334455667788;
 
-/// Fixture for HTTPDigestAuthenticateTest.
-class HTTPDigestAuthenticateTest : public ::testing::Test
+/// Base class for the fixtures used to test the HttpDigestAuthenticate class.
+class HTTPDigestAuthenticateTestBase : public ::testing::Test
+{
+  FakeCounter _auth_challenge_count;
+  FakeCounter _auth_attempt_count;
+  FakeCounter _auth_success_count;
+  FakeCounter _auth_failure_count;
+  FakeCounter _auth_stale_count;
+  FakeHomesteadConnection* _hc;
+  HTTPDigestAuthenticate* _auth_mod;
+  HTTPDigestAuthenticate::Response* _response;
+
+  HTTPDigestAuthenticateTestBase()
+  {
+    _hc = new FakeHomesteadConnection();
+    _response = new HTTPDigestAuthenticate::Response();
+    _auth_mod = NULL;
+  }
+
+  virtual ~HTTPDigestAuthenticateTestBase()
+  {
+    delete _response; _response = NULL;
+    delete _hc; _hc = NULL;
+  }
+};
+
+/// Test fixture that uses an auth store that is backed by a fake store.
+class HTTPDigestAuthenticateTest : public HTTPDigestAuthenticateTestBase
 {
   HTTPDigestAuthenticateTest()
   {
     _local_data_store = new LocalStore();
     _auth_store = new AuthStore(_local_data_store, 300);
-    _hc = new FakeHomesteadConnection();
     _auth_mod = new HTTPDigestAuthenticate(_auth_store,
                                            _hc,
                                            "home.domain",
@@ -70,28 +98,41 @@ class HTTPDigestAuthenticateTest : public ::testing::Test
                                            &_auth_success_count,
                                            &_auth_failure_count,
                                            &_auth_stale_count);
-    _response = new HTTPDigestAuthenticate::Response();
   }
 
   virtual ~HTTPDigestAuthenticateTest()
   {
-    delete _response; _response = NULL;
     delete _auth_mod; _auth_mod = NULL;
-    delete _hc; _hc = NULL;
     delete _auth_store; _auth_store = NULL;
     delete _local_data_store; _local_data_store = NULL;
   }
 
   LocalStore* _local_data_store;
   AuthStore* _auth_store;
-  FakeHomesteadConnection* _hc;
-  FakeCounter _auth_challenge_count;
-  FakeCounter _auth_attempt_count;
-  FakeCounter _auth_success_count;
-  FakeCounter _auth_failure_count;
-  FakeCounter _auth_stale_count;
+};
+
+/// Test fixture that uses a mock auth store.
+class HTTPDigestAuthenticateMockStoreTest : public HTTPDigestAuthenticateTestBase
+{
+  HTTPDigestAuthenticateMockStoreTest()
+  {
+    _auth_mod = new HTTPDigestAuthenticate(&_mock_auth_store,
+                                           _hc,
+                                           "home.domain",
+                                           &_auth_challenge_count,
+                                           &_auth_attempt_count,
+                                           &_auth_success_count,
+                                           &_auth_failure_count,
+                                           &_auth_stale_count);
+  }
+
+  virtual ~HTTPDigestAuthenticateMockStoreTest()
+  {
+    delete _auth_mod; _auth_mod = NULL;
+  }
+
+  MockAuthStore _mock_auth_store;
   HTTPDigestAuthenticate* _auth_mod;
-  HTTPDigestAuthenticate::Response* _response;
 };
 
 TEST_F(HTTPDigestAuthenticateTest, CheckAuthInfo_NoAuthHeader)
@@ -237,7 +278,7 @@ TEST_F(HTTPDigestAuthenticateTest, RequestStoreDigest)
   long rc = _auth_mod->request_digest_and_store(www_auth_header, false, _response);
 
   EXPECT_THAT(www_auth_header,
-              MatchesRegex("Digest realm=\"home\\.domain\",qop=\"auth\",nonce=\".*/KspN6ry7jG8CU4b\",opaque=\".*onN2aujzfJamyN3xYja\""));
+              MatchesRegex("Digest realm=\"home\\.domain\",qop=\"auth\",nonce=\".*\",opaque=\".*\""));
   ASSERT_EQ(rc, 401);
 }
 
@@ -257,7 +298,7 @@ TEST_F(HTTPDigestAuthenticateTest, RequestStoreDigest_Stale)
   long rc = _auth_mod->request_digest_and_store(www_auth_header, true, _response);
 
   EXPECT_THAT(www_auth_header,
-              MatchesRegex("Digest realm=\"home\\.domain\",qop=\"auth\",nonce=\".*dFXYpeUryNGb0UROC0\",opaque=\".*Bh9cHwp\\+hBh8n\\+B\\+Xqc\",stale=TRUE"));
+              MatchesRegex("Digest realm=\"home\\.domain\",qop=\"auth\",nonce=\".*\",opaque=\".*\",stale=TRUE"));
   ASSERT_EQ(rc, 401);
 }
 
@@ -512,6 +553,52 @@ TEST_F(HTTPDigestAuthenticateTest, CheckIfMatches_WrongIMPU)
 
   ASSERT_EQ(rc, 404);
   ASSERT_EQ(_auth_mod->_impi, "1231231231@home.domain");
+
+  delete digest; digest = NULL;
+}
+
+// This test checks the behaviour when the authenticator tries to update the
+// nonce count in the auth store, and the set fails with DATA_CONTENTION. This
+// simulates the case where the nonce has already been used to authenticate a
+// request, and is now stale. The authenticator therefore rechallenges the
+// request with the stale flag set.
+TEST_F(HTTPDigestAuthenticateMockStoreTest, CheckIfMatches_NonceUpdateFails_RaceCondition)
+{
+  // Set up an existing digest to pass into `check_if_matches`.
+  AuthStore::Digest *digest = new AuthStore::Digest();
+  digest->_impi = "1231231231@home.domain";
+  digest->_nonce = "nonce";
+  digest->_ha1 = "123123123";
+  digest->_opaque = "opaque";
+  digest->_realm = "home.domain";
+  digest->_impu = "sip:1231231231@home.domain";
+
+  // The authenticator will request a new digest from homestead. Prepare for
+  // this.
+  std::vector<std::string> test;
+  test.push_back("digest_1");
+  test.push_back("realm");
+  _hc->set_result("/impi/1231231231%40home.domain/av?impu=sip%3A1231231231%40home.domain", test);
+
+  // Set the _impu
+  _auth_mod->set_members("sip:1231231231@home.domain", "GET", "1231231231@home.domain", 0);
+  _response->set_members("1231231231","home.domain","nonce","org.projectclearwater.call-list/users/1231231231@home.domain/call-list.xml","qop","00001","cnonce","242c99c1e20618147c6a325c09720664","opaque");
+
+  // The auth store is called twice:
+  // - Once to update the nonce count on the existing digest (which fails with
+  //   DATA_CONTENTION).
+  // - Once to store the new digest from homestead (which succeeds).
+  EXPECT_CALL(_mock_auth_store, set_digest(_, _, _, _))
+    .WillOnce(Return(Store::DATA_CONTENTION))
+    .WillOnce(Return(Store::OK));
+
+  // Run through check if matches. This should rechallenge the request.
+  std::string www_auth_header;
+  long rc = _auth_mod->check_if_matches(digest, www_auth_header, _response);
+
+  EXPECT_THAT(www_auth_header,
+              MatchesRegex("Digest realm=\"home\\.domain\",qop=\"auth\",nonce=\".*\",opaque=\".*\",stale=TRUE"));
+  ASSERT_EQ(rc, 401);
 
   delete digest; digest = NULL;
 }

--- a/src/ut/httpdigestauthenticate_test.cpp
+++ b/src/ut/httpdigestauthenticate_test.cpp
@@ -440,8 +440,8 @@ TEST_F(HTTPDigestAuthenticateTest, CheckIfMatches_Valid_UpdatesNonceCount)
 
   // Check that the digest's nonce count has been updated in the store.
   AuthStore::Digest* new_digest = NULL;
-  bool store_success = _auth_store->get_digest(orig_digest._impi, orig_digest._nonce, new_digest, DUMMY_TRAIL_ID);
-  EXPECT_TRUE(store_success);
+  Store::Status status = _auth_store->get_digest(orig_digest._impi, orig_digest._nonce, new_digest, DUMMY_TRAIL_ID);
+  EXPECT_EQ(Store::OK, status);
   EXPECT_EQ(2u, new_digest->_nonce_count);
 
   delete new_digest; new_digest = NULL;

--- a/src/ut/mockauthstore.h
+++ b/src/ut/mockauthstore.h
@@ -2,7 +2,7 @@
  * @file mockauthstore.h Mock authentication store object.
  *
  * Project Clearwater - IMS in the cloud.
- * Copyright (C) 2014  Metaswitch Networks Ltd
+ * Copyright (C) 2015  Metaswitch Networks Ltd
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/src/ut/mockauthstore.h
+++ b/src/ut/mockauthstore.h
@@ -1,0 +1,60 @@
+/**
+ * @file mockauthstore.h Mock authentication store object.
+ *
+ * Project Clearwater - IMS in the cloud.
+ * Copyright (C) 2014  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#ifndef MOCKAUTHSTORE_H_
+#define MOCKAUTHSTORE_H_
+
+#include "gmock/gmock.h"
+
+#include "authstore.h"
+
+class MockAuthStore : public AuthStore
+{
+  MockAuthStore() : AuthStore(NULL, 300) {}
+  virtual ~MockAuthStore() {}
+
+  MOCK_METHOD4(set_digest, Store::Status(const std::string&,
+                                         const std::string&,
+                                         const Digest*,
+                                         SAS::TrailId));
+  MOCK_METHOD4(get_digest, Store::Status(const std::string&,
+                                         const std::string&,
+                                         Digest*&,
+                                         SAS::TrailId));
+};
+
+#endif
+


### PR DESCRIPTION
Ellie, please could you my review my fix for #36? 

I have made the following changes:
* The auth store now records the CAS when getting a digest object, and uses it when doing a set. 
* The auth store now returns `Store::Status` codes.
* `HttpDigestAuthenticate` treats CAS mismatches as if the request was stale (see code for explanation). 

All this has been unit tested and all new/changed code is covered. 