### PR TITLE
Setup cassandra redundancy for GR sites

### DIFF
--- a/memento.root/usr/share/clearwater/cassandra-schemas/memento.sh
+++ b/memento.root/usr/share/clearwater/cassandra-schemas/memento.sh
@@ -24,7 +24,7 @@ if [[ ! -e /var/lib/cassandra/data/${keyspace} ]]; then
             printf "*** ERROR: Cassandra did not come online!\n"
             exit 1
         fi
-        netstat -na | grep -q ":7199[^0-9]"
+        $namespace_prefix netstat -na | grep -q ":7199[^0-9]"
     done
     let "cnt=0"
     $namespace_prefix netstat -na | grep "LISTEN" | awk '{ print $4 }' | grep -q ":9160\$"

--- a/memento.root/usr/share/clearwater/cassandra-schemas/memento.sh
+++ b/memento.root/usr/share/clearwater/cassandra-schemas/memento.sh
@@ -1,12 +1,10 @@
-#! /bin/bash
+#!/bin/bash
 
 keyspace=$(basename $0|sed -e 's#^\(.*\)[.]sh$#\1#')
 
 . /etc/clearwater/config
-if [ ! -z $signaling_namespace ]
-then
-    if [ $EUID -ne 0 ]
-    then
+if [ ! -z $signaling_namespace ]; then
+    if [ $EUID -ne 0 ]; then
         echo "When using multiple networks, schema creation must be run as root"
         exit 2
     fi

--- a/memento.root/usr/share/clearwater/cassandra-schemas/memento.sh
+++ b/memento.root/usr/share/clearwater/cassandra-schemas/memento.sh
@@ -1,8 +1,121 @@
 #! /bin/bash
-if [[ ! -e /var/lib/cassandra/data/memento ]];
+
+keyspace=$(basename $0|sed -e 's#^\(.*\)[.]sh$#\1#')
+
+. /etc/clearwater/config
+if [ ! -z $signaling_namespace ]
 then
-    echo "CREATE KEYSPACE memento WITH strategy_class='org.apache.cassandra.locator.SimpleStrategy' AND strategy_options:replication_factor=2;
-          USE memento;
-          CREATE TABLE call_lists (impu text PRIMARY KEY, dummy text) WITH read_repair_chance = 1.0;
-    " | cqlsh -2
+    if [ $EUID -ne 0 ]
+    then
+        echo "When using multiple networks, schema creation must be run as root"
+        exit 2
+    fi
+    namespace_prefix="ip netns exec $signaling_namespace"
+fi
+
+if [[ ! -e /var/lib/cassandra/data/${keyspace} ]]; then
+    header="Waiting for Cassandra"
+    let "cnt=0"
+    $namespace_prefix netstat -na | grep -q ":7199[^0-9]"
+    while [ $? -ne 0 ]; do
+        sleep 1
+        printf "${header}."
+        header=""
+        let "cnt=$cnt + 1"
+        if [ $cnt -gt 120 ]; then
+            printf "*** ERROR: Cassandra did not come online!\n"
+            exit 1
+        fi
+        netstat -na | grep -q ":7199[^0-9]"
+    done
+    let "cnt=0"
+    $namespace_prefix netstat -na | grep "LISTEN" | awk '{ print $4 }' | grep -q ":9160\$"
+    while [ $? -ne 0 ]; do
+        sleep 1
+        printf "${header}+"
+        header=""
+        let "cnt=$cnt + 1"
+        if [ $cnt -gt 120 ]; then
+            printf "*** ERROR: Cassandra did not come online!\n"
+            exit 1
+        fi
+        $namespace_prefix netstat -na | grep "LISTEN" | awk '{ print $4 }' | grep -q ":9160\$"
+    done
+
+    printf "CREATE KEYSPACE ${keyspace} WITH strategy_class = 'SimpleStrategy' AND strategy_options:replication_factor = 2;" > /tmp/$$.cqlsh.in
+
+    $namespace_prefix cqlsh -2 < /tmp/$$.cqlsh.in
+    rm -f /tmp/$$.cqlsh.in
+
+    echo "
+    USE ${keyspace};
+    CREATE TABLE call_lists (impu text PRIMARY KEY, dummy text) WITH read_repair_chance = 1.0;" >> /tmp/$$.cqlsh.in
+
+    $namespace_prefix cqlsh -2 < /tmp/$$.cqlsh.in
+    rm -f /tmp/$$.cqlsh.in
+fi
+
+yaml=/etc/cassandra/cassandra.yaml
+let max_replicas=2
+cassandra_nodes=($(cat ${yaml} | grep "[^#]*seeds:" |
+        sed -e 's#^.*seeds:[ 	]*"\([^"]*\).*$#\1#'|sed -e 's#,# #g'))
+let "num_replicas=${#cassandra_nodes[@]}"
+if [ $num_replicas -gt $max_replicas ]; then
+    let "num_replicas=$max_replicas"
+fi
+snitch=$(grep "^[[:space:]]*endpoint_snitch:" ${yaml}|
+    sed -e 's#endpoint_snitch:[[:space:]]*\([^[:space:]]*\).*#\1#')
+
+if [ "$snitch" == "PropertyFileSnitch" ]; then
+    IFS=$'\r\n' GLOBIGNORE='*' :; topology=(
+        $(egrep "^[[:space:]]*([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+|[0-9a-f\\:]+)[[:space:]]*=" /etc/cassandra/cassandra-topology.properties)
+    )
+
+    dcs=()
+    declare -A dc_num_nodes
+    for loc in "${topology[@]}"; do
+        loc=( 
+            $(echo "$loc"|
+                sed -e 's#\\##g'|sed -e 's#^[[:space:]]*\([^[:space:]]*\)[^=]*=[[:space:]]*\([^:]*\):[[:space:]]*\([^[:space:]]*\).*$#\1 \2 \3#' ) 
+        )
+        
+        dc=${loc[1]}
+        rack=${loc[2]}
+        (for e in ${dcs[@]}; do [[ "$e" == "${dc}" ]] && exit 0; done; exit 1)
+        if [ $? -ne 0 ]; then
+            dcs=( ${dcs[@]} $dc )
+        fi
+        if [ -z ${dc_num_nodes[$dc]} ]; then
+            let "dc_num_nodes[$dc]=0"
+        fi
+        let "dc_num_nodes[$dc]=${dc_num_nodes[$dc]} + 1"
+    done
+
+    # Generate cqlsh input for creating the keyspace
+    (
+        printf "ALTER KEYSPACE \"${keyspace}\" WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', "
+        let "i=0"
+        while [ $i -lt ${#dcs[@]} ]; do
+            let "num_replicas=${dc_num_nodes[${dcs[$i]}]}"
+            if [ $num_replicas -gt $max_replicas ]; then
+                let "num_replicas=$max_replicas"
+            fi
+            if [ $i -ne 0 ]; then
+                printf ", "
+            fi
+            printf "'${dcs[$i]}' : $num_replicas"
+            let "i=$i + 1"
+        done
+        printf " };\n"
+    ) > /tmp/$$.cqlsh.in
+    $namespace_prefix cqlsh -3 < /tmp/$$.cqlsh.in
+
+    rm -f /tmp/$$.cqlsh.in
+else
+    printf "
+ALTER KEYSPACE \"${keyspace}\" WITH REPLICATION =
+  { 'class' : 'SimpleStrategy', 'replication_factor' : $num_replicas };" > /tmp/$$.cqlsh.in
+    $namespace_prefix cqlsh -3 < /tmp/$$.cqlsh.in
+
+    rm -f /tmp/$$.cqlsh.in
 fi


### PR DESCRIPTION
This modification sets Cassandra redundancy (of GR systems) based on the network topology gleened from /etc/cassandra/cassandra-topology.properties.