### PR TITLE
[Reviewer: Rob] Make load monitor options configurable

### DIFF
--- a/debian/memento.init.d
+++ b/debian/memento.init.d
@@ -111,6 +111,10 @@ get_settings()
     alarms_enabled_arg="--alarms-enabled"
   fi
 
+  [ -z "$cass_target_latency_us" ] || cass_target_latency_us_arg="--cass-target-latency-us $cass_target_latency_us"
+  [ -z "$max_tokens" ] || max_tokens_arg="--max-tokens $max_tokens"
+  [ -z "$init_token_rate" ] || init_token_rate_arg="--init-token-rate $init_token_rate"
+  [ -z "$min_token_rate" ] || min_token_rate_arg="--min-token-rate $min_token_rate"
   [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
 }
 
@@ -142,6 +146,10 @@ do_start()
                      --home-domain $home_domain
                      --access-log $log_directory
                      $alarms_enabled_arg
+                     $cass_target_latency_us_arg
+                     $max_tokens_arg
+                     $init_token_rate_arg
+                     $min_token_rate_arg
                      --log-file $log_directory
                      --log-level $log_level
                      --sas $sas_server,$NAME@$public_hostname"

--- a/debian/memento.init.d
+++ b/debian/memento.init.d
@@ -111,7 +111,7 @@ get_settings()
     alarms_enabled_arg="--alarms-enabled"
   fi
 
-  [ -z "$cass_target_latency_us" ] || cass_target_latency_us_arg="--cass-target-latency-us $cass_target_latency_us"
+  [ -z "$target_latency_us" ] || target_latency_us_arg="--target-latency-us $target_latency_us"
   [ -z "$max_tokens" ] || max_tokens_arg="--max-tokens $max_tokens"
   [ -z "$init_token_rate" ] || init_token_rate_arg="--init-token-rate $init_token_rate"
   [ -z "$min_token_rate" ] || min_token_rate_arg="--min-token-rate $min_token_rate"
@@ -146,7 +146,7 @@ do_start()
                      --home-domain $home_domain
                      --access-log $log_directory
                      $alarms_enabled_arg
-                     $cass_target_latency_us_arg
+                     $target_latency_us_arg
                      $max_tokens_arg
                      $init_token_rate_arg
                      $min_token_rate_arg

--- a/include/mementoappserver.h
+++ b/include/mementoappserver.h
@@ -67,19 +67,27 @@ class MementoAppServer : public AppServer
 {
 public:
   /// Constructor.
-  /// @param  service_name          - Service name (memento).
-  /// @param  home_domain           - Home domain of deployment (from configuration).
-  /// @param  max_call_list_length  - Maximum number of calls to store (from configuration).
-  /// @param  memento_thread        - Number of memento threads (from configuration).
-  /// @param  call_list_ttl         - Time to store calls in Cassandra (from configuration).
-  /// @param  stats_aggregator      - Statistics aggregator (last value cache).
+  /// @param  service_name           - Service name (memento).
+  /// @param  home_domain            - Home domain of deployment (from configuration).
+  /// @param  max_call_list_length   - Maximum number of calls to store (from configuration).
+  /// @param  memento_thread         - Number of memento threads (from configuration).
+  /// @param  call_list_ttl          - Time to store calls in Cassandra (from configuration).
+  /// @param  stats_aggregator       - Statistics aggregator (last value cache).
+  /// @param  cass_target_latency_us - Target latency for the Cassandra requests (from configuration).
+  /// @param  max_tokens             - Max number of tokens for the Cassandra load monitor (from configuration).
+  /// @param  init_token_rate        - Initial token rate for the Cassandra load monitor (from configuration).
+  /// @param  min_token_rate         - Minimum token rate for the Cassandra load monitor (from configuration).
   MementoAppServer(const std::string& service_name,
                    CallListStore::Store* call_list_store,
                    const std::string& home_domain,
                    const int max_call_list_length,
                    const int memento_thread,
                    const int call_list_ttl,
-                   LastValueCache* stats_aggregator);
+                   LastValueCache* stats_aggregator,
+                   const int cass_target_latency_us,
+                   const int max_tokens,
+                   const float init_token_rate,
+                   const float min_token_rate);
 
   /// Virtual destructor.
   ~MementoAppServer();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,10 @@ struct options
   int log_level;
   bool alarms_enabled;
   MemcachedWriteFormat memcached_write_format;
+  int cass_target_latency_us;
+  int max_tokens;
+  float init_token_rate;
+  float min_token_rate;
 };
 
 // Enum for option types not assigned short-forms
@@ -97,7 +101,11 @@ enum OptionTypes
   MEMCACHED_WRITE_FORMAT,
   LOG_FILE,
   LOG_LEVEL,
-  HELP
+  HELP,
+  OPT_CASS_TARGET_LATENCY_US,
+  OPT_MAX_TOKENS,
+  OPT_INIT_TOKEN_RATE,
+  OPT_MIN_TOKEN_RATE
 };
 
 const static struct option long_opt[] =
@@ -116,6 +124,10 @@ const static struct option long_opt[] =
   {"log-file",               required_argument, NULL, LOG_FILE},
   {"log-level",              required_argument, NULL, LOG_LEVEL},
   {"help",                   no_argument,       NULL, HELP},
+  {"cass-target-latency-us", required_argument, NULL, OPT_CASS_TARGET_LATENCY_US},
+  {"max-tokens",             required_argument, NULL, OPT_MAX_TOKENS},
+  {"init-token-rate",        required_argument, NULL, OPT_INIT_TOKEN_RATE},
+  {"min-token-rate",         required_argument, NULL, OPT_MIN_TOKEN_RATE},
   {NULL,                     0,                 NULL, 0},
 };
 
@@ -143,6 +155,14 @@ void usage(void)
        "                            The data format to use when writing authentication\n"
        "                            digests to memcached. Values are 'binary' and 'json'\n"
        "                            (defaults to 'binary')\n"
+       " --cass-target-latency-us <usecs>\n"
+       "                            Target latency above which throttling applies (default: 1000000)\n"
+       " --max-tokens N             Maximum number of tokens allowed in the token bucket (used by\n" 
+       "                            the throttling code (default: 20))\n"
+       " --init-token-rate N        Initial token refill rate of tokens in the token bucket (used by\n"
+       "                            the throttling code (default: 100.0))\n"
+       " --min-token-rate N         Minimum token refill rate of tokens in the token bucket (used by\n"
+       "                            the throttling code (default: 10.0))\n"
        " --log-file <directory>\n"
        "                            Log to file in specified directory\n"
        " --log-level N              Set log level to N (default: 4)\n"
@@ -283,6 +303,46 @@ int init_options(int argc, char**argv, struct options& options)
       }
       break;
 
+    case OPT_CASS_TARGET_LATENCY_US:
+      options.cass_target_latency_us = atoi(optarg);
+
+      if (options.cass_target_latency_us <= 0)
+      {
+        LOG_ERROR("Invalid --cass-target-latency-us option %s", optarg);
+        return -1;
+      }
+      break;
+
+    case OPT_MAX_TOKENS:
+      options.max_tokens = atoi(optarg);
+
+      if (options.max_tokens <= 0)
+      {
+        LOG_ERROR("Invalid --max-tokens option %s", optarg);
+        return -1;
+      }
+      break;
+
+    case OPT_INIT_TOKEN_RATE:
+      options.init_token_rate = atoi(optarg);
+ 
+      if (options.init_token_rate <= 0)
+      {
+        LOG_ERROR("Invalid --init-token-rate option %s", optarg);
+        return -1;
+      }
+      break;
+
+    case OPT_MIN_TOKEN_RATE:
+      options.min_token_rate = atoi(optarg);
+
+      if (options.min_token_rate <= 0)
+      {
+        LOG_ERROR("Invalid --min-token-rate option %s", optarg);
+        return -1;
+      }
+      break;
+
     case LOG_FILE:
     case LOG_LEVEL:
       // Ignore these options - they're handled by init_logging_options
@@ -352,6 +412,10 @@ int main(int argc, char**argv)
   options.log_level = 0;
   options.alarms_enabled = false;
   options.memcached_write_format = MemcachedWriteFormat::BINARY;
+  options.cass_target_latency_us = 1000000;
+  options.max_tokens = 20;
+  options.init_token_rate = 100.0;
+  options.min_token_rate = 10.0;
 
   if (init_logging_options(argc, argv, options) != 0)
   {
@@ -462,10 +526,10 @@ int main(int argc, char**argv)
                                         deserializers,
                                         options.digest_timeout);
 
-  LoadMonitor* load_monitor = new LoadMonitor(100000, // Initial target latency (us)
-                                              20, // Maximum token bucket size.
-                                              10.0, // Initial token fill rate (per sec).
-                                              10.0); // Minimum token fill rate (pre sec).
+  LoadMonitor* load_monitor = new LoadMonitor(options.cass_target_latency_us, 
+                                              options.max_tokens,
+                                              options.init_token_rate, 
+                                              options.min_token_rate); 
 
   LastValueCache* stats_aggregator = new MementoLVC();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,7 @@ void usage(void)
        "                            digests to memcached. Values are 'binary' and 'json'\n"
        "                            (defaults to 'binary')\n"
        " --target-latency-us <usecs>\n"
-       "                            Target latency above which throttling applies (default: 1000000)\n"
+       "                            Target latency above which throttling applies (default: 100000)\n"
        " --max-tokens N             Maximum number of tokens allowed in the token bucket (used by\n" 
        "                            the throttling code (default: 20))\n"
        " --init-token-rate N        Initial token refill rate of tokens in the token bucket (used by\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,7 +79,7 @@ struct options
   int log_level;
   bool alarms_enabled;
   MemcachedWriteFormat memcached_write_format;
-  int cass_target_latency_us;
+  int target_latency_us;
   int max_tokens;
   float init_token_rate;
   float min_token_rate;
@@ -102,7 +102,7 @@ enum OptionTypes
   LOG_FILE,
   LOG_LEVEL,
   HELP,
-  CASS_TARGET_LATENCY_US,
+  TARGET_LATENCY_US,
   MAX_TOKENS,
   INIT_TOKEN_RATE,
   MIN_TOKEN_RATE
@@ -124,7 +124,7 @@ const static struct option long_opt[] =
   {"log-file",               required_argument, NULL, LOG_FILE},
   {"log-level",              required_argument, NULL, LOG_LEVEL},
   {"help",                   no_argument,       NULL, HELP},
-  {"cass-target-latency-us", required_argument, NULL, CASS_TARGET_LATENCY_US},
+  {"target-latency-us",      required_argument, NULL, TARGET_LATENCY_US},
   {"max-tokens",             required_argument, NULL, MAX_TOKENS},
   {"init-token-rate",        required_argument, NULL, INIT_TOKEN_RATE},
   {"min-token-rate",         required_argument, NULL, MIN_TOKEN_RATE},
@@ -155,7 +155,7 @@ void usage(void)
        "                            The data format to use when writing authentication\n"
        "                            digests to memcached. Values are 'binary' and 'json'\n"
        "                            (defaults to 'binary')\n"
-       " --cass-target-latency-us <usecs>\n"
+       " --target-latency-us <usecs>\n"
        "                            Target latency above which throttling applies (default: 1000000)\n"
        " --max-tokens N             Maximum number of tokens allowed in the token bucket (used by\n" 
        "                            the throttling code (default: 20))\n"
@@ -303,12 +303,12 @@ int init_options(int argc, char**argv, struct options& options)
       }
       break;
 
-    case CASS_TARGET_LATENCY_US:
-      options.cass_target_latency_us = atoi(optarg);
+    case TARGET_LATENCY_US:
+      options.target_latency_us = atoi(optarg);
 
-      if (options.cass_target_latency_us <= 0)
+      if (options.target_latency_us <= 0)
       {
-        LOG_ERROR("Invalid --cass-target-latency-us option %s", optarg);
+        LOG_ERROR("Invalid --target-latency-us option %s", optarg);
         return -1;
       }
       break;
@@ -412,7 +412,7 @@ int main(int argc, char**argv)
   options.log_level = 0;
   options.alarms_enabled = false;
   options.memcached_write_format = MemcachedWriteFormat::BINARY;
-  options.cass_target_latency_us = 1000000;
+  options.target_latency_us = 100000;
   options.max_tokens = 20;
   options.init_token_rate = 100.0;
   options.min_token_rate = 10.0;
@@ -526,7 +526,7 @@ int main(int argc, char**argv)
                                         deserializers,
                                         options.digest_timeout);
 
-  LoadMonitor* load_monitor = new LoadMonitor(options.cass_target_latency_us, 
+  LoadMonitor* load_monitor = new LoadMonitor(options.target_latency_us, 
                                               options.max_tokens,
                                               options.init_token_rate, 
                                               options.min_token_rate); 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,10 +102,10 @@ enum OptionTypes
   LOG_FILE,
   LOG_LEVEL,
   HELP,
-  OPT_CASS_TARGET_LATENCY_US,
-  OPT_MAX_TOKENS,
-  OPT_INIT_TOKEN_RATE,
-  OPT_MIN_TOKEN_RATE
+  CASS_TARGET_LATENCY_US,
+  MAX_TOKENS,
+  INIT_TOKEN_RATE,
+  MIN_TOKEN_RATE
 };
 
 const static struct option long_opt[] =
@@ -124,10 +124,10 @@ const static struct option long_opt[] =
   {"log-file",               required_argument, NULL, LOG_FILE},
   {"log-level",              required_argument, NULL, LOG_LEVEL},
   {"help",                   no_argument,       NULL, HELP},
-  {"cass-target-latency-us", required_argument, NULL, OPT_CASS_TARGET_LATENCY_US},
-  {"max-tokens",             required_argument, NULL, OPT_MAX_TOKENS},
-  {"init-token-rate",        required_argument, NULL, OPT_INIT_TOKEN_RATE},
-  {"min-token-rate",         required_argument, NULL, OPT_MIN_TOKEN_RATE},
+  {"cass-target-latency-us", required_argument, NULL, CASS_TARGET_LATENCY_US},
+  {"max-tokens",             required_argument, NULL, MAX_TOKENS},
+  {"init-token-rate",        required_argument, NULL, INIT_TOKEN_RATE},
+  {"min-token-rate",         required_argument, NULL, MIN_TOKEN_RATE},
   {NULL,                     0,                 NULL, 0},
 };
 
@@ -303,7 +303,7 @@ int init_options(int argc, char**argv, struct options& options)
       }
       break;
 
-    case OPT_CASS_TARGET_LATENCY_US:
+    case CASS_TARGET_LATENCY_US:
       options.cass_target_latency_us = atoi(optarg);
 
       if (options.cass_target_latency_us <= 0)
@@ -313,7 +313,7 @@ int init_options(int argc, char**argv, struct options& options)
       }
       break;
 
-    case OPT_MAX_TOKENS:
+    case MAX_TOKENS:
       options.max_tokens = atoi(optarg);
 
       if (options.max_tokens <= 0)
@@ -323,7 +323,7 @@ int init_options(int argc, char**argv, struct options& options)
       }
       break;
 
-    case OPT_INIT_TOKEN_RATE:
+    case INIT_TOKEN_RATE:
       options.init_token_rate = atoi(optarg);
  
       if (options.init_token_rate <= 0)
@@ -333,7 +333,7 @@ int init_options(int argc, char**argv, struct options& options)
       }
       break;
 
-    case OPT_MIN_TOKEN_RATE:
+    case MIN_TOKEN_RATE:
       options.min_token_rate = atoi(optarg);
 
       if (options.min_token_rate <= 0)

--- a/src/mementoappserver.cpp
+++ b/src/mementoappserver.cpp
@@ -43,12 +43,6 @@
 #include "utils.h"
 #include "mementosasevent.h"
 
-// Values for the load monitor. Target latency is 1 second
-static const int TARGET_LATENCY = 1000000;
-static const int MAX_TOKENS = 20;
-static float INITIAL_TOKEN_RATE = 100.0;
-static float MIN_TOKEN_RATE = 10.0;
-
 static const int MAX_CALL_ENTRY_LENGTH = 4096;
 static const char* TIMESTAMP_PATTERN = "%Y%m%d%H%M%S";
 static const char* XML_PATTERN = "%Y-%m-%dT%H:%M:%S";
@@ -79,14 +73,18 @@ MementoAppServer::MementoAppServer(const std::string& service_name,
                                    const int max_call_list_length,
                                    const int memento_threads,
                                    const int call_list_ttl,
-                                   LastValueCache* stats_aggregator) :
+                                   LastValueCache* stats_aggregator,
+                                   const int cass_target_latency,
+                                   const int max_tokens,
+                                   const float init_token_rate,
+                                   const float min_token_rate) :
   AppServer(service_name),
   _service_name(service_name),
   _home_domain(home_domain),
-  _load_monitor(new LoadMonitor(TARGET_LATENCY,
-                                MAX_TOKENS,
-                                INITIAL_TOKEN_RATE,
-                                MIN_TOKEN_RATE)),
+  _load_monitor(new LoadMonitor(cass_target_latency,
+                                max_tokens,
+                                init_token_rate,
+                                min_token_rate)),
   _call_list_store_processor(new CallListStoreProcessor(_load_monitor,
                                                         call_list_store,
                                                         max_call_list_length,

--- a/src/ut/mementoappserver_test.cpp
+++ b/src/ut/mementoappserver_test.cpp
@@ -282,7 +282,7 @@ TEST_F(MementoAppServerTest, CreateMementoAppServer)
                                                25,
                                                604800,
                                                _stats_aggregator,
-                                               100000,
+                                               1000000,
                                                20,
                                                100.0,
                                                10.0);

--- a/src/ut/mementoappserver_test.cpp
+++ b/src/ut/mementoappserver_test.cpp
@@ -281,7 +281,11 @@ TEST_F(MementoAppServerTest, CreateMementoAppServer)
                                                0,
                                                25,
                                                604800,
-                                               _stats_aggregator);
+                                               _stats_aggregator,
+                                               100000,
+                                               20,
+                                               100.0,
+                                               10.0);
 
   // Test creating an app server transaction with an invalid method -
   // it shouldn't be created.


### PR DESCRIPTION
Rob, can you review these changes to make the load monitor configurable. They're basically the same as https://github.com/Metaswitch/sprout/pull/944, but I've added a separate latency target for memento/cassandra