### PR TITLE
[Reviewer: Ellie] Remove 'configure' from libmemcached on a 'make clean', so that autoconf...

### DIFF
--- a/mk/libmemcached.mk
+++ b/mk/libmemcached.mk
@@ -1,4 +1,5 @@
 # included mk file for the libmemcached module
+
 LIBMEM_DIR := ${MODULE_DIR}/libmemcached
 LIBMEM_CONFIGURE := ${LIBMEM_DIR}/configure
 LIBMEM_MAKEFILE := ${LIBMEM_DIR}/Makefile
@@ -8,22 +9,23 @@ ${LIBMEM_CONFIGURE}:
 
 ${LIBMEM_MAKEFILE}: ${LIBMEM_CONFIGURE}
 	cd ${LIBMEM_DIR} && ./configure --prefix=${INSTALL_DIR} \
-                                  --with-lib-prefix=${INSTALL_DIR} \
-                                  CFLAGS="-I${INSTALL_DIR}/include" \
-                                  LDFLAGS="-L${INSTALL_DIR}/lib"
+		--with-lib-prefix=${INSTALL_DIR} \
+		CFLAGS="-I${INSTALL_DIR}/include" \
+		LDFLAGS="-L${INSTALL_DIR}/lib"
 
 libmemcached: libevhtp ${LIBMEM_MAKEFILE}
-	make -C ${LIBMEM_DIR}
-	make -C ${LIBMEM_DIR} install
+	${MAKE} -C ${LIBMEM_DIR}
+	${MAKE} -C ${LIBMEM_DIR} install
 
 libmemcached_test: libevhtp ${LIBMEM_MAKEFILE}
-	make -C ${LIBMEM_DIR} test
+	${MAKE} -C ${LIBMEM_DIR} test
 
 libmemcached_clean: ${LIBMEM_MAKEFILE}
-	make -C ${LIBMEM_DIR} clean
+	${MAKE} -C ${LIBMEM_DIR} clean
+	rm ${LIBMEM_CONFIGURE}
 
 libmemcached_distclean: ${LIBMEM_MAKEFILE}
-	make -C ${LIBMEM_DIR} distclean
-
+	${MAKE} -C ${LIBMEM_DIR} distclean
+	rm ${LIBMEM_CONFIGURE}
 
 .PHONY: libmemcached libmemcached_test libmemcached_clean libmemcached_distclean


### PR DESCRIPTION
... gets re-run on the next 'make'

(There are no debian/control updates for 14.04, so this just copies Sprout's libmemcached.mk into memento)