### PR TITLE
[No review required] Memento depends on libevent-2.0-5

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Description: Debugging symbols for memento
 
 Package: memento-libs
 Architecture: any
+Depends: libevent-2.0-5, libevent-pthreads-2.0-5
 Description: Libraries for memento
 
 Package: memento-libs-dbg


### PR DESCRIPTION
Same fix as Metaswitch/homestead#194.