### PR TITLE
Fix outgoing field to be the right way around

### DIFF
--- a/src/mementoappserver.cpp
+++ b/src/mementoappserver.cpp
@@ -413,8 +413,8 @@ void MementoAppServerTsx::on_response(pjsip_msg* rsp, int fork_id)
 
   doc.append_node(from);
 
-  // Set outgoing to 0 if the call is incoming, and 1 otherwise.
-  std::string outgoing_str = _outgoing ? "0" : "1";
+  // Set outgoing to 1 if the call is incoming, and 0 otherwise.
+  std::string outgoing_str = _outgoing ? "1" : "0";
   rapidxml::xml_node<>* outgoing = doc.allocate_node(
                                          rapidxml::node_element,
 					 MementoXML::OUTGOING,
@@ -432,7 +432,7 @@ void MementoAppServerTsx::on_response(pjsip_msg* rsp, int fork_id)
 
   if (rsp->line.status.code >= 300)
   {
-    // If the call was rejected, set answered to 1.
+    // If the call was rejected, set answered to 0.
     rapidxml::xml_node<>* answered = doc.allocate_node(rapidxml::node_element,
                                                        MementoXML::ANSWERED,
                                                        "0");
@@ -441,7 +441,7 @@ void MementoAppServerTsx::on_response(pjsip_msg* rsp, int fork_id)
   }
   else
   {
-    // If the call was rejected, set answered to 0. Also fill in the answer time
+    // If the call was answered, set answered to 1. Also fill in the answer time
     // with the current time.
     rapidxml::xml_node<>* answered = doc.allocate_node(rapidxml::node_element,
                                                        MementoXML::ANSWERED,

--- a/src/mementoappserver.cpp
+++ b/src/mementoappserver.cpp
@@ -413,7 +413,7 @@ void MementoAppServerTsx::on_response(pjsip_msg* rsp, int fork_id)
 
   doc.append_node(from);
 
-  // Set outgoing to 1 if the call is incoming, and 0 otherwise.
+  // Set outgoing to 1 if the call is outgoing, and 0 otherwise.
   std::string outgoing_str = _outgoing ? "1" : "0";
   rapidxml::xml_node<>* outgoing = doc.allocate_node(
                                          rapidxml::node_element,

--- a/src/ut/mementoappserver_test.cpp
+++ b/src/ut/mementoappserver_test.cpp
@@ -335,7 +335,7 @@ TEST_F(MementoAppServerTest, MainlineIncomingTest)
   // Check that the xml, impu and CallFragment type are as expected
   std::string xml = std::string("<to>\n\t<URI>sip:6505551234@homedomain</URI>\n</to>\n<from>" \
                                 "\n\t<URI>sip:6505551000@homedomain</URI>\n\t<name>Alice</name>" \
-                                "\n</from>\n<outgoing>1</outgoing>\n<start-time>").
+                                "\n</from>\n<outgoing>0</outgoing>\n<start-time>").
                     append(timestamp).append("</start-time>\n<answered>1</answered>\n<answer-time>").
                     append(timestamp).append("</answer-time>\n\n");
   std::string impu = "sip:6505551234@homedomain";
@@ -378,7 +378,7 @@ TEST_F(MementoAppServerTest, MainlineOutgoingTest)
 
   std::string xml = std::string("<to>\n\t<URI>sip:6505551234@homedomain</URI>\n\t<name>Bob</name>\n" \
                                 "</to>\n<from>\n\t<URI>sip:6505550000@homedomain</URI>\n\t<name>Alice</name>\n" \
-                                "</from>\n<outgoing>0</outgoing>\n<start-time>").
+                                "</from>\n<outgoing>1</outgoing>\n<start-time>").
                     append(timestamp).append("</start-time>\n<answered>1</answered>\n<answer-time>").
                     append(timestamp).append("</answer-time>\n\n");
   std::string impu = "sip:6505550000@homedomain";
@@ -485,7 +485,7 @@ TEST_F(MementoAppServerTest, OnErrorResponse)
   // Check that the xml, impu and CallFragment type are as expected
   std::string xml = std::string("<to>\n\t<URI>sip:6505551234@homedomain</URI>\n</to>\n<from>" \
                                 "\n\t<URI>sip:6505551000@homedomain</URI>\n\t<name>Alice</name>" \
-                                "\n</from>\n<outgoing>1</outgoing>\n<start-time>").
+                                "\n</from>\n<outgoing>0</outgoing>\n<start-time>").
                     append(timestamp).append("</start-time>\n<answered>0</answered>\n\n");
   std::string impu = "sip:6505551234@homedomain";
   EXPECT_CALL(*_clsp, write_call_list_entry(impu, _, _, CallListStore::CallFragment::Type::REJECTED, xml, _));


### PR DESCRIPTION
The "outgoing" field in the call logs was previously the reverse of what it should be. The code was disagreeing with a comment above it.

This fix puts it the right way around, and also reorders/corrects some surrounding comments.