### PR TITLE
Fix to the handling of reINVITEs

### DIFF
--- a/include/mementoappserver.h
+++ b/include/mementoappserver.h
@@ -212,6 +212,9 @@ private:
 
   /// IMPU of the call list owner
   std::string _impu;
+
+  /// Flag for whether this transaction includes the initial dialog request.
+  bool _includes_initial_request;
 };
 
 /// Utility methods

--- a/src/call_list_store.cpp
+++ b/src/call_list_store.cpp
@@ -278,6 +278,14 @@ bool GetCallFragments::perform(CassandraStore::Client* client,
     std::vector<std::string> tokens;
     Utils::split_string(column_it->column.name, '_', tokens);
 
+    if (tokens.size() != 3)
+    {
+      // LCOV_EXCL_START
+      TRC_WARNING("Invalid column name (%s)", column_it->column.name.c_str());
+      continue;
+      // LCOV_EXCL_STOP
+    }
+
     std::string& timestamp_str = tokens[0];
     std::string& id_str = tokens[1];
     std::string& type_str = tokens[2];


### PR DESCRIPTION
Previously, in dialog requests other than BYEs caused an END record to be
created (e.g. reINVITEs). Also, 200 OKs to reINVITEs were treated like
200 OKs to the initial INVITE, and a BEGIN record was created.
This begin record was also corrupted, due to timestamps not being set up
in on_initial_request.

This fix includes:
- Ignore reINVITEs - don't create an END record
- Ignore 200 OKs to everything but the initial INVITE
- Handle corrupted columns better on a http request