### PR TITLE
Add NGV-API-Key header support

### DIFF
--- a/debian/memento.init.d
+++ b/debian/memento.init.d
@@ -111,6 +111,7 @@ get_settings()
   [ -z "$min_token_rate" ] || min_token_rate_arg="--min-token-rate $min_token_rate"
   [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
   [ -z "$exception_max_ttl" ] || exception_max_ttl_arg="--exception-max-ttl $exception_max_ttl"
+  [ -z "$memento_api_key" ] || api_key_arg="--api-key $memento_api_key"
 }
 
 #
@@ -147,7 +148,8 @@ do_start()
                      $exception_max_ttl_arg
                      --log-file $log_directory
                      --log-level $log_level
-                     --sas $sas_server,$NAME@$public_hostname"
+                     --sas $sas_server,$NAME@$public_hostname
+                     $api_key_arg"
         [ "$http_blacklist_duration" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --http-blacklist-duration=$http_blacklist_duration"
 
         $namespace_prefix start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON --chuid $NAME --chdir $HOME -- $DAEMON_ARGS \

--- a/docs/memento_overview.md
+++ b/docs/memento_overview.md
@@ -40,6 +40,8 @@ This supports GETs to retrieve an entire call list for a public user identity; a
 
 Requests to this URL must be authenticated. Memento uses [HTTP Digest authentication] (http://tools.ietf.org/html/rfc2617), and supports the "auth" quality of protection. Memento uses the credentials provisioned in homestead for authenticating requests, in a similar way to how Sprout authenticates SIP REGISTERs. Memento also authorizes requests, ensuring that the authenticated IMPI is permitted to access the IMPU referred to in the URL of the request.
 
+Alternatively, trusted servers can authenticate requests using an NGV-API-Key header containing the API key defined by the `memento_api_key` setting in shared config.  Requests authenticated with this mechanism are authorized to access any call list.
+
 If the request has been authorized and authenticated Memento retrieves the call list fragments relating to the request IMPU from the call list store.
 If there are entries, Memento will create an XML document containing complete calls and return this to the client
 

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -58,12 +58,14 @@ public:
            CallListStore::Store* call_list_store,
            std::string home_domain,
            LastValueCache* stats_aggregator,
-           HealthChecker* hc) :
+           HealthChecker* hc,
+           std::string api_key) :
       _auth_store(auth_store),
       _homestead_conn(homestead_conn),
       _call_list_store(call_list_store),
       _home_domain(home_domain),
-      _health_checker(hc) 
+      _health_checker(hc),
+      _api_key(api_key)
     {
       _stat_auth_challenge_count = new StatisticCounter("auth_challenges",
                                                         stats_aggregator);
@@ -100,6 +102,7 @@ public:
     CallListStore::Store* _call_list_store;
     std::string _home_domain;
     HealthChecker* _health_checker;
+    std::string _api_key;
     StatisticCounter* _stat_auth_challenge_count;
     StatisticCounter* _stat_auth_attempt_count;
     StatisticCounter* _stat_auth_success_count;

--- a/memento-nginx.root/usr/share/clearwater/infrastructure/scripts/create-memento-nginx-config
+++ b/memento-nginx.root/usr/share/clearwater/infrastructure/scripts/create-memento-nginx-config
@@ -82,6 +82,9 @@ server {
                 # The client may have instructed the server to close the
                 # connection - do not forward this upstream.
                 proxy_set_header Connection "";
+
+                # Do not forward any NGV-API-Key header upstream.
+                proxy_set_header NGV-API-Key "";
         }
 
         location /org.projectclearwater.call-list {
@@ -91,6 +94,9 @@ server {
                 # The client may have instructed the server to close the
                 # connection - do not forward this upstream.
                 proxy_set_header Connection "";
+
+                # Do not forward any NGV-API-Key header upstream.
+                proxy_set_header NGV-API-Key "";
 
                 gzip on;
                 gzip_types *;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,7 @@ struct options
   float min_token_rate;
   int exception_max_ttl;
   int http_blacklist_duration;
+  std::string api_key;
 };
 
 // Enum for option types not assigned short-forms
@@ -110,7 +111,8 @@ enum OptionTypes
   INIT_TOKEN_RATE,
   MIN_TOKEN_RATE,
   EXCEPTION_MAX_TTL,
-  HTTP_BLACKLIST_DURATION
+  HTTP_BLACKLIST_DURATION,
+  API_KEY
 };
 
 const static struct option long_opt[] =
@@ -134,6 +136,7 @@ const static struct option long_opt[] =
   {"min-token-rate",           required_argument, NULL, MIN_TOKEN_RATE},
   {"exception-max-ttl",        required_argument, NULL, EXCEPTION_MAX_TTL},
   {"http-blacklist-duration",  required_argument, NULL, HTTP_BLACKLIST_DURATION},
+  {"api-key",                  required_argument, NULL, API_KEY},
   {NULL,                       0,                 NULL, 0},
 };
 
@@ -173,6 +176,9 @@ void usage(void)
        "                            The actual time is randomised.\n"
        " --http-blacklist-duration <secs>\n"
        "                            The amount of time to blacklist an HTTP peer when it is unresponsive.\n"
+       " --api-key <key>            Value of NGV-API-Key header that is used to authenticate requests\n"
+       "                            for servers in the cluster.  These requests do not require user\n"
+       "                            authentication.\n"
        " --log-file <directory>\n"
        "                            Log to file in specified directory\n"
        " --log-level N              Set log level to N (default: 4)\n"
@@ -358,6 +364,12 @@ int init_options(int argc, char**argv, struct options& options)
       options.http_blacklist_duration = atoi(optarg);
       TRC_INFO("HTTP blacklist duration set to %d",
                options.http_blacklist_duration);
+      break;
+
+    case API_KEY:
+      options.api_key = std::string(optarg);
+      TRC_INFO("HTTP API key set to %s",
+               options.api_key.c_str());
       break;
 
     case LOG_FILE:
@@ -594,7 +606,7 @@ int main(int argc, char**argv)
   HttpStack* http_stack = HttpStack::get_instance();
   HttpStackUtils::SimpleStatsManager stats_manager(stats_aggregator);
 
-  CallListTask::Config call_list_config(auth_store, homestead_conn, call_list_store, options.home_domain, stats_aggregator, hc);
+  CallListTask::Config call_list_config(auth_store, homestead_conn, call_list_store, options.home_domain, stats_aggregator, hc, options.api_key);
 
   MementoSasLogger sas_logger;
   HttpStackUtils::PingHandler ping_handler;

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -149,10 +149,7 @@ TEST_F(HandlersTest, ApiKey)
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
   handler->run();
 
-  EXPECT_EQ((
-              "<call-list><calls>"
-              "</calls></call-list>"),
-            req.content());
+  EXPECT_EQ("<call-list><calls></calls></call-list>", req.content());
 }
 
 TEST_F(HandlersTest, InvalidApiKey)

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -73,7 +73,7 @@ public:
     _call_store = new MockCallListStore();
     _hc = new FakeHomesteadConnection();
     _health_checker = new HealthChecker();
-    _cfg = new CallListTask::Config(_auth_store, _hc, _call_store, "localhost", _stats_aggregator, _health_checker);
+    _cfg = new CallListTask::Config(_auth_store, _hc, _call_store, "localhost", _stats_aggregator, _health_checker, "APIKEY");
 
   }
   virtual ~HandlersTest()
@@ -129,6 +129,60 @@ TEST_F(HandlersTest, HandlerCreationInvalidMethod)
   CallListTask* handler = new CallListTask(req, _cfg, 0);
 
   EXPECT_CALL(*_httpstack, send_reply(_, 405, _));
+  handler->run();
+}
+
+TEST_F(HandlersTest, ApiKey)
+{
+  std::vector<CallListStore::CallFragment> records;
+  MockHttpStack::Request req(_httpstack,
+                             "/org.projectclearwater.call-list/users/sip:6505551234@home.domain/call-list.xml",
+                             "",
+                             "");
+  req.add_header_to_incoming_req("NGV-API-Key", "APIKEY");
+
+  CallListTask* handler = new CallListTask(req, _cfg, 0);
+
+  EXPECT_CALL(*_call_store, get_call_fragments_sync(_, _, _))
+    .WillOnce(DoAll(SetArgReferee<1>(records), Return(CassandraStore::ResultCode::OK)));
+
+  EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
+  handler->run();
+
+  EXPECT_EQ((
+              "<call-list><calls>"
+              "</calls></call-list>"),
+            req.content());
+}
+
+TEST_F(HandlersTest, InvalidApiKey)
+{
+  std::vector<CallListStore::CallFragment> records;
+  MockHttpStack::Request req(_httpstack,
+                             "/org.projectclearwater.call-list/users/sip:6505551234@home.domain/call-list.xml",
+                             "",
+                             "");
+  req.add_header_to_incoming_req("NGV-API-Key", "INVALID-APIKEY");
+
+  CallListTask* handler = new CallListTask(req, _cfg, 0);
+
+  EXPECT_CALL(*_httpstack, send_reply(_, 404, _));
+  handler->run();
+}
+
+TEST_F(HandlersTest, EmptyApiKey)
+{
+  std::vector<CallListStore::CallFragment> records;
+  CallListTask::Config cfg(_auth_store, _hc, _call_store, "localhost", _stats_aggregator, _health_checker, "");
+  MockHttpStack::Request req(_httpstack,
+                             "/org.projectclearwater.call-list/users/sip:6505551234@home.domain/call-list.xml",
+                             "",
+                             "");
+  req.add_header_to_incoming_req("NGV-API-Key", "");
+
+  CallListTask* handler = new CallListTask(req, &cfg, 0);
+
+  EXPECT_CALL(*_httpstack, send_reply(_, 404, _));
   handler->run();
 }
 
@@ -453,7 +507,7 @@ TEST_F(HandlersTest, DbError)
 TEST_F(HandlersTest, HTTPOKPassesHealthCheck)
 {
   MockHealthChecker mock_health_checker;
-  CallListTask::Config cfg(_auth_store, _hc, _call_store, "localhost", _stats_aggregator, &mock_health_checker);
+  CallListTask::Config cfg(_auth_store, _hc, _call_store, "localhost", _stats_aggregator, &mock_health_checker, "APIKEY");
 
   MockHttpStack::Request req(_httpstack, "/", "", "");
 
@@ -472,7 +526,7 @@ TEST_F(HandlersTest, HTTPOKPassesHealthCheck)
 TEST_F(HandlersTest, HTTPErrorFailsHealthCheck)
 {
   MockHealthChecker mock_health_checker;
-  CallListTask::Config cfg(_auth_store, _hc, _call_store, "localhost", _stats_aggregator, &mock_health_checker);
+  CallListTask::Config cfg(_auth_store, _hc, _call_store, "localhost", _stats_aggregator, &mock_health_checker, "APIKEY");
 
   MockHttpStack::Request req(_httpstack, "/", "", "");
 


### PR DESCRIPTION
Requests from trusted servers within the cluster can be made using an `NGV-API-Key` header to authenticate the request.  Requests authenticated using this mechanism are authorized to access any call list.