### PR TITLE
Record who answered a call

### DIFF
--- a/docs/memento_overview.md
+++ b/docs/memento_overview.md
@@ -59,6 +59,10 @@ If there are entries, Memento will create an XML document containing complete ca
       <outgoing>1</outgoing>
       <start-time>2002-05-30T09:30:10</start-time>
       <answer-time>2002-05-30T09:30:20</answer-time>
+      <answerer>
+        <URI>bob@example.com</URI>
+        <name>Bob Barker</name>
+      </answerer>
       <end-time>2002-05-30T09:35:00</end-time>
     </call>
     <call>

--- a/include/mementoappserver.h
+++ b/include/mementoappserver.h
@@ -180,9 +180,6 @@ private:
   /// Home domain of deployment.
   std::string _home_domain;
 
-  /// Flag for whether the call has been answered or rejected
-  bool _answered;
-
   /// Flag for whether the call is incoming or outgoing
   bool _outgoing;
 
@@ -201,6 +198,12 @@ private:
 
   /// Callee URI
   std::string _callee_uri;
+
+  /// Answerer name (can be empty)
+  std::string _answerer_name;
+
+  /// Answerer URI
+  std::string _answerer_uri;
 
   /// Flag for whether a response has already been received on this
   /// transaction


### PR DESCRIPTION
For calls that are forwarded by an app server, the person who answered a call may be different to the person for whom the call was originally to.  Record who this is by saving the contents of the `P-A-I` header on the `200 OK` to the initial `INVITE`.

This is made available through a new `<answerer>` element in the call list document.