### PR TITLE
Allow memento to send notifications to HTTP servers

### DIFF
--- a/docs/memento_overview.md
+++ b/docs/memento_overview.md
@@ -86,6 +86,15 @@ If there are no entries, Memento will respond with an empty call list, i.e.:
 
 Memento supports gzip compression of the call list document, and will compress it in the HTTP response if the requesting client indicates it is willing to accept gzip encoding.
 
+HTTP Notification Interface
+---------------------------
+
+Mement supports notifications via HTTP whenever a subscriber's call list is updated.  When a notification URL is configured, memento will make a POST to that URL each time call list is updated.  The body of the POST request will be a JSON document of the form:
+
+```json
+{ "impu": "<subscriber's IMPU>" }
+```
+
 Configuration
 -------------
 
@@ -110,12 +119,13 @@ An example IFC is:
 </InitialFilterCriteria>
 ```
 
-There are also four deployment wide configuration options. These should be set in /etc/clearwater/config:
+There are also five deployment wide configuration options. These should be set in /etc/clearwater/config:
 
 * `max_call_list_length`: This determines the maximum number of complete calls a subscriber can have in the call list store. This defaults to no limit.
 * `call_list_store_ttl`: This determines how long each call list fragment should be kept in the call list store. This defaults to 604800 seconds (1 week).
 * `memento_threads`: This determines the number of threads dedicated to adding call list fragments to the call list store. This defaults to 25 threads
 * `memento_disk_limit`: This determines the maximum size that the call lists database may occupy. This defaults to 20% of disk space.
+* `memento_notify_url`: If set, memento will make a POST request to this URL whenever a subscriber's call list is changed.
 
 Scalability
 -----------

--- a/include/call_list_store_processor.h
+++ b/include/call_list_store_processor.h
@@ -44,6 +44,7 @@
 #include "mementosasevent.h"
 #include "counter.h"
 #include "accumulator.h"
+#include "httpnotifier.h"
 
 class CallListStoreProcessor
 {
@@ -55,7 +56,8 @@ public:
                          const int memento_thread,
                          const int call_list_ttl,
                          LastValueCache* stats_aggregator,
-                         ExceptionHandler* exception_handler);
+                         ExceptionHandler* exception_handler,
+                         HttpNotifier* notifier);
 
   /// Destructor
   virtual ~CallListStoreProcessor();
@@ -116,6 +118,7 @@ private:
          unsigned int num_threads,
          ExceptionHandler* exception_handler,
          void (*callback)(CallListStoreProcessor::CallListRequest* work),
+         HttpNotifier* http_notifier,
          unsigned int max_queue = 0);
 
     /// Destructor
@@ -159,6 +162,9 @@ private:
 
     /// Parent call list store processor.
     CallListStoreProcessor* _call_list_store_proc;
+
+    /// Notifier
+    HttpNotifier* _http_notifier;
   };
 
   friend class Pool;

--- a/include/httpnotifier.h
+++ b/include/httpnotifier.h
@@ -44,20 +44,17 @@ class HttpNotifier
 {
 public:
   /// Constructor
-  HttpNotifier(HttpResolver* resolver);
+  HttpNotifier(HttpResolver* resolver, const std::string& notify_url);
 
   /// Destructor
   virtual ~HttpNotifier();
-
-  /// Set the URL to send notifications to.
-  void set_url(const std::string& notify_url);
 
   /// This function sends a HTTP POST to the notify URL, to notify it of the
   /// fact that a call list for a user has updated. This is synchronous.
   /// Returns true iff the request was successful.
   /// @param impu       IMPU of the member whose call list has been updated
   /// @param trail      The SAS trail
-  bool send_notify(std::string impu, SAS::TrailId trail);
+  virtual bool send_notify(const std::string& impu, SAS::TrailId trail);
 
 private:
 

--- a/include/httpnotifier.h
+++ b/include/httpnotifier.h
@@ -1,8 +1,8 @@
 /**
- * @file mock_call_list_store_processor.h Mock call list store object.
+ * @file httpnotifier.h
  *
- * Project Clearwater - IMS in the cloud.
- * Copyright (C) 2014  Metaswitch Networks Ltd
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2015  Metaswitch Networks Ltd
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -34,23 +34,41 @@
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
-#ifndef MOCK_CALL_LIST_STORE_PROCESSOR_H_
-#define MOCK_CALL_LIST_STORE_PROCESSOR_H_
+#ifndef HTTPNOTIFIER_H__
+#define HTTPNOTIFIER_H__
 
-#include "call_list_store_processor.h"
+#include "httpconnection.h"
+#include "sas.h"
 
-class MockCallListStoreProcessor : public CallListStoreProcessor
+class HttpNotifier
 {
 public:
-  MockCallListStoreProcessor() : CallListStoreProcessor(NULL, NULL, 0, 0, 0, NULL, NULL, NULL) {}
-  virtual ~MockCallListStoreProcessor() {};
+  /// Constructor
+  HttpNotifier(HttpResolver* resolver);
 
-  MOCK_METHOD6(write_call_list_entry, void(std::string impu,
-                                           std::string timestamp,
-                                           std::string id,
-                                           CallListStore::CallFragment::Type type,
-                                           std::string xml,
-                                           SAS::TrailId trail));
+  /// Destructor
+  virtual ~HttpNotifier();
+
+  /// Set the URL to send notifications to.
+  void set_url(const std::string& notify_url);
+
+  /// This function sends a HTTP POST to the notify URL, to notify it of the
+  /// fact that a call list for a user has updated. This is synchronous.
+  /// Returns true iff the request was successful.
+  /// @param impu       IMPU of the member whose call list has been updated
+  /// @param trail      The SAS trail
+  bool send_notify(std::string impu, SAS::TrailId trail);
+
+private:
+
+  /// Resolver
+  HttpResolver *_http_resolver;
+
+  /// Connection
+  HttpConnection *_http_connection;
+
+  /// URL path
+  std::string _http_url_path;
 };
 
 #endif

--- a/include/mementoappserver.h
+++ b/include/mementoappserver.h
@@ -77,6 +77,8 @@ public:
   /// @param  max_tokens             - Max number of tokens for the Cassandra load monitor (from configuration).
   /// @param  init_token_rate        - Initial token rate for the Cassandra load monitor (from configuration).
   /// @param  min_token_rate         - Minimum token rate for the Cassandra load monitor (from configuration).
+  /// @param  http_resolver          - HTTP resolver to use for HTTP connections.
+  /// @param  memento_notify_url     - HTTP URL that memento should notify when call lists change.
   MementoAppServer(const std::string& service_name,
                    CallListStore::Store* call_list_store,
                    const std::string& home_domain,
@@ -88,7 +90,9 @@ public:
                    const int max_tokens,
                    const float init_token_rate,
                    const float min_token_rate,
-                   ExceptionHandler* exception_handler);
+                   ExceptionHandler* exception_handler,
+                   HttpResolver* http_resolver,
+                   const std::string& memento_notify_url);
 
   /// Virtual destructor.
   ~MementoAppServer();
@@ -114,6 +118,9 @@ private:
 
   /// Load monitor.
   LoadMonitor* _load_monitor;
+
+  /// HTTP notifier.
+  HttpNotifier* _http_notifier;
 
   /// Call list store processor.
   CallListStoreProcessor* _call_list_store_processor;

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,8 @@ TARGET_SOURCES := localstore.cpp \
                   memento_lvc.cpp \
                   health_checker.cpp \
                   exception_handler.cpp \
-                  namespace_hop.cpp
+                  namespace_hop.cpp \
+                  httpnotifier.cpp
 
 TARGET_SOURCES_BUILD := main.cpp
 
@@ -72,7 +73,9 @@ TARGET_SOURCES_TEST := test_main.cpp \
                        faketransport_udp.cpp \
                        faketransport_tcp.cpp \
                        mock_sas.cpp \
-                       memento_lvc.cpp
+                       memento_lvc.cpp \
+                       httpnotifier_test.cpp \
+                       mockhttpnotifier.cpp
 
 TARGET_EXTRA_OBJS_TEST := gmock-all.o \
                           gtest-all.o

--- a/src/httpnotifier.cpp
+++ b/src/httpnotifier.cpp
@@ -41,24 +41,9 @@
 #include "rapidjson/stringbuffer.h"
 
 /// Constructor.
-HttpNotifier::HttpNotifier(HttpResolver* resolver) :
+HttpNotifier::HttpNotifier(HttpResolver* resolver, const std::string& notify_url) :
   _http_resolver(resolver),
-  _http_connection(NULL),
-  _http_url_path()
-{
-}
-
-/// Destructor.
-HttpNotifier::~HttpNotifier()
-{
-  if (_http_connection != NULL)
-  {
-    delete _http_connection; _http_connection = NULL;
-  }
-}
-
-/// Set notification URL.
-void HttpNotifier::set_url(const std::string& notify_url)
+  _http_connection(NULL)
 {
   std::string url_server;
   std::string url_path;
@@ -76,8 +61,17 @@ void HttpNotifier::set_url(const std::string& notify_url)
   }
 }
 
+/// Destructor.
+HttpNotifier::~HttpNotifier()
+{
+  if (_http_connection != NULL)
+  {
+    delete _http_connection; _http_connection = NULL;
+  }
+}
+
 /// Notify that a subscriber's call list has changed
-bool HttpNotifier::send_notify(std::string impu,
+bool HttpNotifier::send_notify(const std::string& impu,
                                SAS::TrailId trail)
 {
   if (_http_connection == NULL)

--- a/src/httpnotifier.cpp
+++ b/src/httpnotifier.cpp
@@ -53,8 +53,6 @@ HttpNotifier::HttpNotifier(HttpResolver* resolver, const std::string& notify_url
     _http_connection = new HttpConnection(url_server,
                                           true,
                                           _http_resolver,
-                                          NULL,
-                                          NULL,
                                           SASEvent::HttpLogLevel::PROTOCOL,
                                           NULL);
     _http_url_path = url_path;
@@ -93,10 +91,9 @@ bool HttpNotifier::send_notify(const std::string& impu,
   std::map<std::string, std::string> headers;
   std::string body = buffer.GetString();
 
-  HTTPCode http_code = _http_connection->send_post(
-      _http_url_path,
-      headers,
-      body,
-      trail);
+  HTTPCode http_code = _http_connection->send_post(_http_url_path,
+                                                   headers,
+                                                   body,
+                                                   trail);
   return (http_code == HTTP_OK);
 }

--- a/src/httpnotifier.cpp
+++ b/src/httpnotifier.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file httpnotifier.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2015  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "httpnotifier.h"
+
+#include <rapidjson/document.h>
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+
+/// Constructor.
+HttpNotifier::HttpNotifier(HttpResolver* resolver) :
+  _http_resolver(resolver),
+  _http_connection(NULL),
+  _http_url_path()
+{
+}
+
+/// Destructor.
+HttpNotifier::~HttpNotifier()
+{
+  if (_http_connection != NULL)
+  {
+    delete _http_connection; _http_connection = NULL;
+  }
+}
+
+/// Set notification URL.
+void HttpNotifier::set_url(const std::string& notify_url)
+{
+  std::string url_server;
+  std::string url_path;
+  if (Utils::parse_http_url(notify_url, url_server, url_path) &&
+      !url_server.empty())
+  {
+    _http_connection = new HttpConnection(url_server,
+                                          true,
+                                          _http_resolver,
+                                          NULL,
+                                          NULL,
+                                          SASEvent::HttpLogLevel::PROTOCOL,
+                                          NULL);
+    _http_url_path = url_path;
+  }
+}
+
+/// Notify that a subscriber's call list has changed
+bool HttpNotifier::send_notify(std::string impu,
+                               SAS::TrailId trail)
+{
+  if (_http_connection == NULL)
+  {
+    // No notifier attached.  Do nothing.
+    return true;
+  }
+
+  rapidjson::Document notification;
+  notification.SetObject();
+  rapidjson::Value impu_value;
+  impu_value.SetString(impu.c_str(), notification.GetAllocator());
+  notification.AddMember("impu", impu_value, notification.GetAllocator());
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  notification.Accept(writer);
+
+  std::map<std::string, std::string> headers;
+  std::string body = buffer.GetString();
+
+  HTTPCode http_code = _http_connection->send_post(
+      _http_url_path,
+      headers,
+      body,
+      trail);
+  return (http_code == HTTP_OK);
+}

--- a/src/mementoappserver.cpp
+++ b/src/mementoappserver.cpp
@@ -90,7 +90,7 @@ MementoAppServer::MementoAppServer(const std::string& service_name,
                                 max_tokens,
                                 init_token_rate,
                                 min_token_rate)),
-  _http_notifier(new HttpNotifier(http_resolver)),
+  _http_notifier(new HttpNotifier(http_resolver, memento_notify_url)),
   _call_list_store_processor(new CallListStoreProcessor(_load_monitor,
                                                         call_list_store,
                                                         max_call_list_length,
@@ -102,10 +102,6 @@ MementoAppServer::MementoAppServer(const std::string& service_name,
   _stat_calls_not_recorded_due_to_overload("memento_not_recorded_overload",
                                            stats_aggregator)
 {
-  if (!memento_notify_url.empty())
-  {
-    _http_notifier->set_url(memento_notify_url);
-  }
 }
 
 /// Destructor.

--- a/src/ut/call_list_store_processor_test.cpp
+++ b/src/ut/call_list_store_processor_test.cpp
@@ -44,6 +44,7 @@
 #include "call_list_store_processor.h"
 #include "mock_call_list_store.h"
 #include "mockloadmonitor.hpp"
+#include "mockhttpnotifier.h"
 #include "memento_lvc.h"
 
 using ::testing::Return;
@@ -79,9 +80,10 @@ public:
                                            known_stats,
                                            zmq_port,
                                            10);
+    _http_notifier = new MockHttpNotifier();
 
     // No maximum call length and 1 worker thread
-    _clsp = new CallListStoreProcessor(&_load_monitor, _cls, 0, 1, CALL_LIST_TTL, _stats_aggregator, NULL);
+    _clsp = new CallListStoreProcessor(&_load_monitor, _cls, 0, 1, CALL_LIST_TTL, _stats_aggregator, NULL, _http_notifier);
   }
 
   virtual ~CallListStoreProcessorTest()
@@ -89,12 +91,14 @@ public:
     delete _cls; _cls = NULL;
     delete _stats_aggregator; _stats_aggregator = NULL;
     delete _clsp; _clsp = NULL;
+    delete _http_notifier; _http_notifier = NULL;
   }
 
   StrictMock<MockLoadMonitor> _load_monitor;
   CallListStoreProcessor* _clsp;
   MockCallListStore* _cls;
   LastValueCache* _stats_aggregator;
+  MockHttpNotifier* _http_notifier;
 };
 
 // Fixture for tests that has a low limit to the number of stored call lists
@@ -108,9 +112,10 @@ public:
                                            known_stats,
                                            zmq_port,
                                            10);
+    _http_notifier = new MockHttpNotifier();
 
     // Maximum call length of 4 and 2 worker threads
-    _clsp = new CallListStoreProcessor(&_load_monitor, _cls, 4, 2, CALL_LIST_TTL, _stats_aggregator, NULL);
+    _clsp = new CallListStoreProcessor(&_load_monitor, _cls, 4, 2, CALL_LIST_TTL, _stats_aggregator, NULL, _http_notifier);
   }
 
   virtual ~CallListStoreProcessorWithLimitTest()
@@ -118,12 +123,14 @@ public:
     delete _cls; _cls = NULL;
     delete _stats_aggregator; _stats_aggregator = NULL;
     delete _clsp; _clsp = NULL;
+    delete _http_notifier; _http_notifier = NULL;
   }
 
   StrictMock<MockLoadMonitor> _load_monitor;
   CallListStoreProcessor* _clsp;
   MockCallListStore* _cls;
   LastValueCache* _stats_aggregator;
+  MockHttpNotifier* _http_notifier;
 };
 
 // Create a vector of call list store fragments that the mock

--- a/src/ut/call_list_store_processor_test.cpp
+++ b/src/ut/call_list_store_processor_test.cpp
@@ -271,6 +271,7 @@ TEST_F(CallListStoreProcessorTest, CallListIsCountNeededNoLimit)
 TEST_F(CallListStoreProcessorTest, CallListWriteBegin)
 {
   EXPECT_CALL(_load_monitor, request_complete(_)).Times(1);
+  EXPECT_CALL(*_http_notifier, send_notify(_, _)).Times(1);
 
   EXPECT_CALL(*_cls, write_call_fragment_sync(IMPU, _, _, CALL_LIST_TTL, FAKE_SAS_TRAIL)).WillOnce(Return(CassandraStore::ResultCode::OK));
   _clsp->write_call_list_entry(IMPU, TIMESTAMP, "id", CallListStore::CallFragment::Type::BEGIN, "xml", FAKE_SAS_TRAIL);
@@ -280,6 +281,7 @@ TEST_F(CallListStoreProcessorTest, CallListWriteBegin)
 TEST_F(CallListStoreProcessorTest, CallListWriteEnd)
 {
   EXPECT_CALL(_load_monitor, request_complete(_)).Times(1);
+  EXPECT_CALL(*_http_notifier, send_notify(_, _)).Times(1);
 
   EXPECT_CALL(*_cls, write_call_fragment_sync(IMPU, _, _, CALL_LIST_TTL, FAKE_SAS_TRAIL)).WillOnce(Return(CassandraStore::ResultCode::OK));
   _clsp->write_call_list_entry(IMPU, TIMESTAMP, "id", CallListStore::CallFragment::Type::END, "xml", FAKE_SAS_TRAIL);
@@ -289,6 +291,7 @@ TEST_F(CallListStoreProcessorTest, CallListWriteEnd)
 TEST_F(CallListStoreProcessorTest, CallListWriteRejected)
 {
   EXPECT_CALL(_load_monitor, request_complete(_)).Times(1);
+  EXPECT_CALL(*_http_notifier, send_notify(_, _)).Times(1);
 
   EXPECT_CALL(*_cls, write_call_fragment_sync(IMPU, _, _, CALL_LIST_TTL, FAKE_SAS_TRAIL)).WillOnce(Return(CassandraStore::ResultCode::OK));
   _clsp->write_call_list_entry(IMPU, TIMESTAMP, "id", CallListStore::CallFragment::Type::REJECTED, "xml", FAKE_SAS_TRAIL);
@@ -309,6 +312,7 @@ TEST_F(CallListStoreProcessorWithLimitTest, CallListWriteWithTrim)
   create_records(records);
 
   EXPECT_CALL(_load_monitor, request_complete(_)).Times(1);
+  EXPECT_CALL(*_http_notifier, send_notify(_, _)).Times(1);
   EXPECT_CALL(*_cls, write_call_fragment_sync(_, _, _, _, _)).WillOnce(Return(CassandraStore::ResultCode::OK));
   EXPECT_CALL(*_cls, get_call_fragments_sync(_,_,_)).WillOnce(DoAll(SetArgReferee<1>(records),
                                                                     Return(CassandraStore::ResultCode::OK)));

--- a/src/ut/httpnotifier_test.cpp
+++ b/src/ut/httpnotifier_test.cpp
@@ -56,7 +56,7 @@ class HttpNotifierTest : public ::testing::Test
 
   HttpNotifierTest() :
     _resolver("10.42.42.42"),
-    _http_notifier(&_resolver)
+    _http_notifier(&_resolver, "http://notification.domain/notify")
   {
     fakecurl_responses.clear();
     fakecurl_responses["http://10.42.42.42:80/notify"] = "";
@@ -74,7 +74,6 @@ class HttpNotifierTest : public ::testing::Test
 
 TEST_F(HttpNotifierTest, Notify)
 {
-  _http_notifier.set_url("http://notification.domain/notify");
   bool ret = _http_notifier.send_notify("user@domain", 0);
   EXPECT_TRUE(ret);
   Request& req = fakecurl_requests["http://10.42.42.42:80/notify"];
@@ -82,3 +81,34 @@ TEST_F(HttpNotifierTest, Notify)
   EXPECT_EQ("{\"impu\":\"user@domain\"}", req._body);
 }
 
+/// Fixture for HttpNotifierEmptyTest.
+class HttpNotifierEmptyTest : public ::testing::Test
+{
+  FakeHttpResolver _resolver;
+  HttpNotifier _http_notifier;
+
+  HttpNotifierEmptyTest() :
+    _resolver("10.42.42.42"),
+    _http_notifier(&_resolver, "")
+  {
+    fakecurl_responses.clear();
+    fakecurl_responses["http://10.42.42.42:80/notify"] = "";
+    fakecurl_requests.clear();
+  }
+
+  virtual ~HttpNotifierEmptyTest()
+  {
+    fakecurl_responses.clear();
+    fakecurl_requests.clear();
+  }
+};
+
+
+// Now test the higher-level methods.
+
+TEST_F(HttpNotifierEmptyTest, Notify)
+{
+  bool ret = _http_notifier.send_notify("user@domain", 0);
+  EXPECT_TRUE(ret);
+  EXPECT_TRUE(fakecurl_requests.empty());
+}

--- a/src/ut/mementoappserver_test.cpp
+++ b/src/ut/mementoappserver_test.cpp
@@ -286,7 +286,9 @@ TEST_F(MementoAppServerTest, CreateMementoAppServer)
                                                20,
                                                100.0,
                                                10.0,
-                                               NULL); // Exception Handler
+                                               NULL, // Exception Handler
+                                               NULL, // HTTP Resolver
+                                               "http://example.com/notify");
 
   // Test creating an app server transaction with an invalid method -
   // it shouldn't be created.

--- a/src/ut/mockhttpnotifier.cpp
+++ b/src/ut/mockhttpnotifier.cpp
@@ -37,7 +37,7 @@
 #include "mockhttpnotifier.h"
 
 MockHttpNotifier::MockHttpNotifier() :
-    HttpNotifier(NULL)
+    HttpNotifier(NULL, "")
   {}
 
 MockHttpNotifier::~MockHttpNotifier() {}

--- a/src/ut/mockhttpnotifier.cpp
+++ b/src/ut/mockhttpnotifier.cpp
@@ -1,8 +1,8 @@
 /**
- * @file mock_call_list_store_processor.h Mock call list store object.
+ * @file mockhttpnotifier.cpp Mock http notifier.
  *
- * Project Clearwater - IMS in the cloud.
- * Copyright (C) 2014  Metaswitch Networks Ltd
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2015  Metaswitch Networks Ltd
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -34,23 +34,10 @@
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
-#ifndef MOCK_CALL_LIST_STORE_PROCESSOR_H_
-#define MOCK_CALL_LIST_STORE_PROCESSOR_H_
+#include "mockhttpnotifier.h"
 
-#include "call_list_store_processor.h"
+MockHttpNotifier::MockHttpNotifier() :
+    HttpNotifier(NULL)
+  {}
 
-class MockCallListStoreProcessor : public CallListStoreProcessor
-{
-public:
-  MockCallListStoreProcessor() : CallListStoreProcessor(NULL, NULL, 0, 0, 0, NULL, NULL, NULL) {}
-  virtual ~MockCallListStoreProcessor() {};
-
-  MOCK_METHOD6(write_call_list_entry, void(std::string impu,
-                                           std::string timestamp,
-                                           std::string id,
-                                           CallListStore::CallFragment::Type type,
-                                           std::string xml,
-                                           SAS::TrailId trail));
-};
-
-#endif
+MockHttpNotifier::~MockHttpNotifier() {}

--- a/src/ut/mockhttpnotifier.h
+++ b/src/ut/mockhttpnotifier.h
@@ -47,9 +47,6 @@ public:
   MockHttpNotifier();
   virtual ~MockHttpNotifier();
 
-  MOCK_METHOD1(set_url,
-               void(const std::string& url));
-
   MOCK_METHOD2(send_notify,
                bool(const std::string& impu,
                     SAS::TrailId triail));

--- a/src/ut/mockhttpnotifier.h
+++ b/src/ut/mockhttpnotifier.h
@@ -1,8 +1,8 @@
 /**
- * @file mock_call_list_store_processor.h Mock call list store object.
+ * @file mockhttpnotifier.h Mock HttpNotifier object
  *
  * Project Clearwater - IMS in the cloud.
- * Copyright (C) 2014  Metaswitch Networks Ltd
+ * Copyright (C) 2015  Metaswitch Networks Ltd
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -34,23 +34,26 @@
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
-#ifndef MOCK_CALL_LIST_STORE_PROCESSOR_H_
-#define MOCK_CALL_LIST_STORE_PROCESSOR_H_
+#ifndef MOCKHTTPNOTIFIER_H_
+#define MOCKHTTPNOTIFIER_H_
 
-#include "call_list_store_processor.h"
+#include <gmock/gmock.h>
 
-class MockCallListStoreProcessor : public CallListStoreProcessor
+#include "httpnotifier.h"
+
+class MockHttpNotifier : public HttpNotifier
 {
 public:
-  MockCallListStoreProcessor() : CallListStoreProcessor(NULL, NULL, 0, 0, 0, NULL, NULL, NULL) {}
-  virtual ~MockCallListStoreProcessor() {};
+  MockHttpNotifier();
+  virtual ~MockHttpNotifier();
 
-  MOCK_METHOD6(write_call_list_entry, void(std::string impu,
-                                           std::string timestamp,
-                                           std::string id,
-                                           CallListStore::CallFragment::Type type,
-                                           std::string xml,
-                                           SAS::TrailId trail));
+  MOCK_METHOD1(set_url,
+               void(const std::string& url));
+
+  MOCK_METHOD2(send_notify,
+               bool(const std::string& impu,
+                    SAS::TrailId triail));
 };
 
 #endif
+


### PR DESCRIPTION
Adds change notifications to memento.  When a notification URL is set, memento will make a POST request to that URL whenever a subscriber's call list is changed.  The POST body is a JSON document of the form:

```json
{ "impu": "<subscriber's impu>" }
```

This allows other servers in the cluster to react asynchronously to call lists changing.