### PR TITLE
Clang compile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -112,7 +112,7 @@ memento_test_LDFLAGS := ${COMMON_LDFLAGS} -lcurl
 
 include ../build-infra/cpp.mk
 
-ROOT := $(abspath $(shell pwd)/../)
+ROOT := ..
 MODULE_DIR := ${ROOT}/modules
 include ../modules/cpp-common/makefiles/alarm-utils.mk
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -64,7 +64,9 @@ memento_test_SOURCES := ${COMMON_SOURCES} \
                         faketransport_tcp.cpp \
                         mock_sas.cpp \
                         httpnotifier_test.cpp \
-                        mockhttpnotifier.cpp
+                        mockhttpnotifier.cpp \
+                        snmp_ip_count_table.cpp \
+                        snmp_row.cpp
 
 COMMON_CPPFLAGS := -I../include \
                    -I../usr/include \


### PR DESCRIPTION
Not entirely sure why clang finds that it needs to know about more code
than gcc - but it does.