### PR TITLE
[Reviewer: None] Use updated check-uptime script.

### DIFF
--- a/memento.root/usr/share/clearwater/infrastructure/scripts/memento.monit
+++ b/memento.root/usr/share/clearwater/infrastructure/scripts/memento.monit
@@ -54,11 +54,11 @@ check process memento_process with pidfile /var/run/memento/memento.pid
   if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 5000.3; /etc/init.d/memento abort'"
 
 # Clear any alarms if the process has been running long enough.
-check program memento_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/memento/memento.pid"
+check program memento_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/memento/memento.pid monit 5000.1"
   group memento
   depends on memento_process
   every 3 cycles
-  if status = 0 then exec "/usr/share/clearwater/bin/issue_alarm.py monit 5000.1"
+  if status != 0 then alert
 
 # Check the HTTP interface. This depends on the Memento process (and so won't run
 # unless the Memento process is running)


### PR DESCRIPTION
Use check-uptime to clear alarms and avoid suprious monit failures.