### PR TITLE
[No Reviewer] Change max_tokens default to 100

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,7 +173,7 @@ void usage(void)
        " --target-latency-us <usecs>\n"
        "                            Target latency above which throttling applies (default: 100000)\n"
        " --max-tokens N             Maximum number of tokens allowed in the token bucket (used by\n"
-       "                            the throttling code (default: 20))\n"
+       "                            the throttling code (default: 100))\n"
        " --init-token-rate N        Initial token refill rate of tokens in the token bucket (used by\n"
        "                            the throttling code (default: 100.0))\n"
        " --min-token-rate N         Minimum token refill rate of tokens in the token bucket (used by\n"
@@ -462,7 +462,7 @@ int main(int argc, char**argv)
   options.log_level = 0;
   options.memcached_write_format = MemcachedWriteFormat::JSON;
   options.target_latency_us = 100000;
-  options.max_tokens = 20;
+  options.max_tokens = 100;
   options.init_token_rate = 100.0;
   options.min_token_rate = 10.0;
   options.exception_max_ttl = 600;


### PR DESCRIPTION
Increasing the default max_tokens value to improve tolerance of small bursts in traffic.