### PR TITLE
Switch from Python version of bracket_ipv6_address to C++ version

### DIFF
--- a/debian/memento.init.d
+++ b/debian/memento.init.d
@@ -87,7 +87,7 @@ get_settings()
   num_http_worker_threads=$(( $num_cpus * 50 ))
   . /etc/clearwater/config
 
-  homestead_http_name=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $hs_hostname)
+  homestead_http_name=$(/usr/share/clearwater/bin/bracket-ipv6-address $hs_hostname)
 
   # Set up a default cluster_settings file if it does not exist.
   [ -f /etc/clearwater/cluster_settings ] || echo "servers=$local_ip:11211" > /etc/clearwater/cluster_settings

--- a/memento.root/usr/share/clearwater/bin/poll_memento.sh
+++ b/memento.root/usr/share/clearwater/bin/poll_memento.sh
@@ -36,6 +36,6 @@
 
 # Note this doesn't work in multiple networks
 . /etc/clearwater/config
-http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 /usr/share/clearwater/bin/poll-http $http_ip:11888
 exit $?


### PR DESCRIPTION
Same as https://github.com/Metaswitch/clearwater-infrastructure/pull/332, but for this repo.