### PR TITLE
[Reviewer: Krista] Get return code from cassandra schemas

### DIFF
--- a/memento-cassandra.root/usr/share/clearwater/cassandra-schemas/memento.sh
+++ b/memento-cassandra.root/usr/share/clearwater/cassandra-schemas/memento.sh
@@ -1,36 +1,42 @@
 #! /bin/bash
-. /usr/share/clearwater/cassandra_schema_utils.sh
 
 cassandra_hostname="127.0.0.1"
 
 . /etc/clearwater/config
+. /usr/share/clearwater/utils/check-root-permissions 1
+. /usr/share/clearwater/cassandra_schema_utils.sh
 
 quit_if_no_cassandra
 
-CQLSH="/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh"
+echo "Adding/updating Cassandra schemas..."
 
-if [[ ! -e /var/lib/cassandra/data/memento ]] || \
-   [[ $cassandra_hostname != "127.0.0.1" ]];
-then
-  echo "Adding Cassandra schemas..."
-  count=0
+# Wait for the cassandra cluster to come online
+count=0
+/usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
+
+while [ $? -ne 0 ]; do
+  ((count++))
+  if [ $count -gt 120 ]; then
+    echo "Cassandra isn't responsive, unable to add/update schemas yet"
+    exit 1
+  fi
+
+  sleep 1
   /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
 
-  while [ $? -ne 0 ]; do
-    ((count++))
-    if [ $count -gt 120 ]; then
-      echo "Cassandra isn't responsive, unable to add schemas"
-      exit 1
-    fi
+done
 
-    sleep 1
-    /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
-  done
+CQLSH="/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh"
 
-  # replication_str is set up by
-  # /usr/share/clearwater/cassandra-schemas/replication_string.sh
-  echo "CREATE KEYSPACE IF NOT EXISTS memento WITH REPLICATION = $replication_str;
-        USE memento;
-        CREATE TABLE IF NOT EXISTS call_lists (impu text PRIMARY KEY, dummy text) WITH COMPACT STORAGE and read_repair_chance = 1.0;
-  " | $CQLSH
+rc=0
+
+if [[ ! -e /var/lib/cassandra/data/cedar ]] || \
+   [[ $cassandra_hostname != "127.0.0.1" ]];
+then
+  $CQLSH -e "CREATE KEYSPACE IF NOT EXISTS memento WITH REPLICATION = $replication_str;
+             USE memento;
+             CREATE TABLE IF NOT EXISTS call_lists (impu text PRIMARY KEY, dummy text) WITH COMPACT STORAGE and read_repair_chance = 1.0;"
+  rc=$?
 fi
+
+exit $rc

--- a/memento-cassandra.root/usr/share/clearwater/cassandra-schemas/memento.sh
+++ b/memento-cassandra.root/usr/share/clearwater/cassandra-schemas/memento.sh
@@ -30,7 +30,7 @@ CQLSH="/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh"
 
 rc=0
 
-if [[ ! -e /var/lib/cassandra/data/cedar ]] || \
+if [[ ! -e /var/lib/cassandra/data/memento ]] || \
    [[ $cassandra_hostname != "127.0.0.1" ]];
 then
   $CQLSH -e "CREATE KEYSPACE IF NOT EXISTS memento WITH REPLICATION = $replication_str;


### PR DESCRIPTION
This adds a return code to adding the schemas so we can retry if it fails, and moves the Memento schema script to have the same format as the homestead-prov schema script.

Tested live.