### PR TITLE
[Reviewer: Richard] Memento fixes

### DIFF
--- a/debian/memento.init.d
+++ b/debian/memento.init.d
@@ -56,7 +56,6 @@ log_directory=/var/log/$NAME
 get_settings()
 {
   # Set up defaults and then pull in the settings for this node.
-  sas_server=0.0.0.0
   local num_cpus=$(grep processor /proc/cpuinfo | wc -l)
   num_http_threads=$num_cpus
   num_http_worker_threads=$(( $num_cpus * 50 ))
@@ -133,7 +132,7 @@ do_start()
                      $exception_max_ttl_arg
                      --log-file $log_directory
                      --log-level $log_level
-                     --sas $sas_server,$NAME@$public_hostname
+                     --sas $NAME@$public_hostname
                      $api_key_arg"
         [ "$http_blacklist_duration" = "" ]       || DAEMON_ARGS="$DAEMON_ARGS --http-blacklist-duration=$http_blacklist_duration"
         [ "$astaire_blacklist_duration" = "" ]    || DAEMON_ARGS="$DAEMON_ARGS --astaire-blacklist-duration=$astaire_blacklist_duration"

--- a/memento-nginx.root/usr/share/clearwater/infrastructure/scripts/create-memento-nginx-config
+++ b/memento-nginx.root/usr/share/clearwater/infrastructure/scripts/create-memento-nginx-config
@@ -27,7 +27,7 @@ then
   enabled_file=/etc/nginx/sites-enabled/memento
   cat > $temp_file << EOF
 upstream http_backend {
-        server localhost:11888;
+        server ${local_ip}:11888;
 
         # The minimum number of idle connections to keep alive to the backend.
         keepalive 16;

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,6 +9,7 @@ COMMON_SOURCES := localstore.cpp \
                   signalhandler.cpp \
                   logger.cpp \
                   saslogger.cpp \
+                  sasservice.cpp \
                   statistic.cpp \
                   utils.cpp \
                   load_monitor.cpp \
@@ -97,6 +98,8 @@ COMMON_LDFLAGS += -lzmq \
                   -lpthread \
                   -lcares \
                   -lboost_regex \
+                  -lboost_thread \
+                  -lboost_system \
                   -lthrift \
                   -lcassandra \
                   `net-snmp-config --netsnmp-agent-libs`


### PR DESCRIPTION
Two fixes here:

1. nginx was forwarding to `localhost`, but Memento's HTTP stack listens on the `local_ip` (as set in the init.d script: https://github.com/Metaswitch/memento/blob/dev/debian/memento.init.d#L120)

1. Updates to Memento to use the new SAS config, basically just taken from the corresponding Homestead changes (https://github.com/Metaswitch/homestead/pull/513/files)

### Testing
`make` and `make full_test` both pass. I've installed on the staging Sprout, and verified that it fixes the problems with poll HTTP and the problems with configuring SAS. Also verified that the memento live tests pass.